### PR TITLE
Chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: check-json
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.0
+    rev: v0.15.1
     hooks:
       - id: ruff
         args:
@@ -40,7 +40,7 @@ repos:
       - id: black
 
   - repo: https://github.com/myint/autoflake
-    rev: v2.3.1
+    rev: v2.3.2
     hooks:
       - id: autoflake
         args: [ --remove-all-unused-imports, --remove-unused-variables ]
@@ -56,15 +56,15 @@ repos:
         ]
         exclude: ^(tests/|migrations/|scripts/)
         additional_dependencies:
-          - fastapi==0.128.1
+          - fastapi==0.129.0
           - pydantic==2.12.5
           - sqlalchemy==2.0.46
           - celery==5.6.2
           - sentry-sdk==2.52.0
-          - pydantic-settings==2.12.0
-          - redis==7.1.0
+          - pydantic-settings==2.13.0
+          - redis==7.1.1
           - pytest==9.0.2
-          - alembic==1.18.3
+          - alembic==1.18.4
           - fastapi-mail==1.6.1
-          - types-passlib==1.7.7.20250602
+          - types-passlib==1.7.7.20260211
           - types-pytz==2025.2.0.20251108


### PR DESCRIPTION
Automated update of `.pre-commit-config.yaml` hook revisions via `pre-commit autoupdate`.