### PR TITLE
Chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
         files: ^infra/requirements/.*\.in$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.7
+    rev: v0.15.8
     hooks:
       - id: ruff
         args:
@@ -67,7 +67,7 @@ repos:
           - fastapi==0.135.2
           - pydantic==2.12.5
           - sqlalchemy==2.0.48
-          - celery==5.6.2
+          - celery==5.6.3
           - PyJWT==2.12.1
           - sentry-sdk==2.56.0
           - pydantic-settings==2.13.1
@@ -77,5 +77,5 @@ repos:
           - fastapi-mail==1.6.2
           - types-passlib==1.7.7.20260211
           - types-PyYAML==6.0.12.20250915
-          - types-requests==2.32.4.20260324
+          - types-requests==2.33.0.20260327
           - types-ujson==5.10.0.20250822


### PR DESCRIPTION
Automated update of `.pre-commit-config.yaml` hook revisions via `pre-commit autoupdate`.