### PR TITLE
Docs: sync CI security docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,11 @@ Production-ready FastAPI template with modular architecture, async stack, Celery
 ![Pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)
 
 ## Security Checks
-- CI runs a dedicated security job in `.github/workflows/ci.yml`.
+- CI runs dedicated security jobs in `.github/workflows/ci.yml`.
 - `bandit` scans application, migration, and script code for insecure patterns.
 - `pip-audit` checks pinned files `infra/requirements/base.txt`, `infra/requirements/dev.txt`, and `infra/requirements/prod.txt` for known vulnerable packages.
 - `gitleaks` scans the repository for committed secrets.
 - `gitleaks` keeps history scanning enabled and uses a repo allowlist only for known example/test placeholders.
-- `pip-audit` currently ignores `CVE-2026-4539` explicitly because `pygments==2.19.2` is present in the dev graph and no fix version is reported yet.
 - These checks are intended to fail the pipeline on real findings, so dependency updates should keep the pinned requirement files current.
 
 ## Quick Start
@@ -85,7 +84,7 @@ Production-ready FastAPI template with modular architecture, async stack, Celery
 ## Optional Local Security Runs
 - Install tools: `pip install bandit pip-audit`
 - Static scan: `bandit -r src scripts migrations -q`
-- Dependency audit: `pip-audit --ignore-vuln CVE-2026-4539 -r infra/requirements/base.txt -r infra/requirements/dev.txt -r infra/requirements/prod.txt`
+- Dependency audit: `pip-audit -r infra/requirements/base.txt -r infra/requirements/dev.txt -r infra/requirements/prod.txt`
 - Secret scan: `gitleaks detect --source .`
 
 ## Dependencies (pip-tools)

--- a/docs/readme/contributing.md
+++ b/docs/readme/contributing.md
@@ -11,12 +11,11 @@
 ### CI (`.github/workflows/ci.yml`)
 - Caching: venv by `infra/requirements.txt` hash, pre-commit, deps.
 - Quality: `make check-lint`, Alembic head check.
-- Tests: generates `.env` from example and runs `make test`.
-- Security: separate `security` job runs `bandit`, `pip-audit`, and `gitleaks`.
+- Tests: generates `.env` from example and runs `make test-cov`.
+- Security: separate `bandit`, `pip-audit`, and `gitleaks` jobs run security checks.
 - Dependency audit uses pinned files `infra/requirements/base.txt`, `infra/requirements/dev.txt`, and `infra/requirements/prod.txt` instead of floating installs.
 - `gitleaks` keeps history scanning enabled and relies on a narrow repo allowlist only for known example/test placeholders.
-- `pip-audit` may contain a temporary ignore only for a specific CVE when no fix version is available yet.
-- The security job is expected to fail on real findings, so dependency bumps should keep lockfiles current.
+- Security jobs are expected to fail on real findings, so dependency bumps should keep lockfiles current.
 
 ### CD (`.github/workflows/deploy.yml`)
 - Deploys from `main` after successful CI.


### PR DESCRIPTION
  ## Summary
  - Sync README and contributing docs with current CI security jobs.
  - Remove obsolete `pip-audit --ignore-vuln CVE-2026-4539` docs.
  - Document that CI runs `make test-cov`.