### PR TITLE
Refactor Docker configuration to improve security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/README.md
+++ b/README.md
@@ -63,15 +63,19 @@ Production-ready FastAPI template with modular architecture, async stack, Celery
 - Run a focused file with `TESTING=true pytest tests/unit/src/<module>/test_<name>.py`.
 
 ## Ports
-- Nginx: 8000 → app:8001
-- App direct: 8001
-- Postgres: 5432
-- Redis: 6379
-- RabbitMQ: 5672 (AMQP), 15672 (UI)
+Only Nginx is published to the host; the rest stay internal to `app-network`.
+Backing ports are re-exposed on `127.0.0.1` in dev (`make run-dev`) only — see
+`docs/readme/security.md` → *Host Port Exposure (Docker & UFW)*.
+
+- Nginx: 8000 → app:8001 — **public** (`0.0.0.0`)
+- App direct: 8001 — internal (dev: `127.0.0.1`)
+- Postgres: 5432 — internal (dev: `127.0.0.1`)
+- Redis: 6379 — internal (dev: `127.0.0.1`)
+- RabbitMQ: 5672 (AMQP), 15672 (UI) — internal (dev: `127.0.0.1`)
 
 ## Common Services
-- API docs: http://localhost:8000/docs (or http://localhost:8001/docs directly)
-- Health: http://localhost:8001/health/
+- API docs: http://localhost:8000/docs (direct app http://localhost:8001/docs — dev only)
+- Health: http://localhost:8000/health/ (direct app http://localhost:8001/health/ — dev only)
 
 ## Useful Make Targets
 - `make run-dev` — build+up with override (reload)

--- a/README.md
+++ b/README.md
@@ -35,16 +35,22 @@ Production-ready FastAPI template with modular architecture, async stack, Celery
 ![Pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)
 
 ## Security Checks
-- CI runs a dedicated security job in `.github/workflows/ci.yml`.
+- CI runs dedicated security jobs in `.github/workflows/ci.yml`.
 - `bandit` scans application, migration, and script code for insecure patterns.
 - `pip-audit` checks pinned files `infra/requirements/base.txt`, `infra/requirements/dev.txt`, and `infra/requirements/prod.txt` for known vulnerable packages.
 - `gitleaks` scans the repository for committed secrets.
 - `gitleaks` keeps history scanning enabled and uses a repo allowlist only for known example/test placeholders.
-- `pip-audit` currently ignores `CVE-2026-4539` explicitly because `pygments==2.19.2` is present in the dev graph and no fix version is reported yet.
 - These checks are intended to fail the pipeline on real findings, so dependency updates should keep the pinned requirement files current.
 
 ## Quick Start
 - Install Docker and Docker Compose, Python 3.13 (for local scripts/hooks).
+- Create and activate a local virtualenv:
+  ```bash
+  python3.13 -m venv .venv
+  source .venv/bin/activate
+  python -m pip install --upgrade pip pip-tools
+  make req-sync-dev
+  ```
 - Copy env: `cp .env.example .env` and fill required values. For tests you can also use `.env.test` (picked up when `TESTING=true` in env).
 - Dev with reload: `make run-dev` (Nginx on 8000, app on 8001).
 - Prod-like: `make run`.
@@ -77,7 +83,7 @@ Production-ready FastAPI template with modular architecture, async stack, Celery
 - `make test-cov` — tests with coverage report
 
 ## Pre-commit Hooks
-- Install dev deps: `pip install -r infra/requirements/dev.txt`
+- Install dev deps: `make req-sync-dev`
 - Update hooks: `pre-commit autoupdate` (and commit `.pre-commit-config.yaml` changes)
 - Clean hook envs if needed: `pre-commit clean`
 - Run all hooks locally: `pre-commit run --all-files` or `make lint`
@@ -85,7 +91,7 @@ Production-ready FastAPI template with modular architecture, async stack, Celery
 ## Optional Local Security Runs
 - Install tools: `pip install bandit pip-audit`
 - Static scan: `bandit -r src scripts migrations -q`
-- Dependency audit: `pip-audit --ignore-vuln CVE-2026-4539 -r infra/requirements/base.txt -r infra/requirements/dev.txt -r infra/requirements/prod.txt`
+- Dependency audit: `pip-audit -r infra/requirements/base.txt -r infra/requirements/dev.txt -r infra/requirements/prod.txt`
 - Secret scan: `gitleaks detect --source .`
 
 ## Dependencies (pip-tools)

--- a/docs/readme/infra.md
+++ b/docs/readme/infra.md
@@ -1,11 +1,24 @@
 # Infrastructure and Operations
 
 ## Services and Ports
-- Nginx: 8000 (proxies to app)
-- App: 8001 (FastAPI)
-- Postgres: 5432
-- Redis: 6379
-- RabbitMQ: 5672 (AMQP), 15672 (UI)
+
+Only **Nginx** is published to the host. All other services are internal-only —
+they talk to each other over the `app-network` bridge by service name and are
+never bound to a host interface in production.
+
+| Service | Port | Host exposure |
+|---|---|---|
+| Nginx | 8000 | **Public** (`0.0.0.0`) — proxies to `app:8001` |
+| App | 8001 | Internal only (dev: `127.0.0.1:8001` for direct access) |
+| Postgres | 5432 | Internal only (dev: `127.0.0.1:5432`) |
+| Redis | 6379 | Internal only (dev: `127.0.0.1:6379`) |
+| RabbitMQ | 5672 / 15672 | Internal only (dev: `127.0.0.1:5672` / `127.0.0.1:15672`) |
+
+Backing-service host ports live **only** in `docker-compose.override.yml` (dev)
+and are bound to `127.0.0.1`. `make run` / `make up` (base file) publish nothing
+but Nginx. This avoids exposing data stores to the internet via the Docker
+iptables/UFW bypass — see `docs/readme/security.md` → *Host Port Exposure
+(Docker & UFW)*.
 
 Configs live in `infra/` (compose, nginx, dockerfiles, redis/postgres, requirements).
 
@@ -35,7 +48,8 @@ make run              # prod-like build
 Open:
 - App via Nginx: http://localhost:8000
 - Docs: http://localhost:8000/docs
-- Direct app (bypass Nginx): http://localhost:8001/docs
+- Direct app (bypass Nginx): http://localhost:8001/docs — **dev only** (`make
+  run-dev`); the base/prod stack does not publish the app port.
 
 ## Common Commands
 ```bash
@@ -64,11 +78,13 @@ make clean            # remove stack + volumes/images/orphans
 ## Troubleshooting
 - Ensure Docker/Compose are installed.
 - `.env` must be filled (ports, DB/Redis/RabbitMQ credentials). `.env.test` used for local test runs `make test` / `make test-cov`.
+- Host-side integration tests that connect to `localhost` (per `.env.test`) need the backing-service ports, which are published on `127.0.0.1` only in dev — start the stack with `make run-dev` first. `make run` / `make up` no longer publish them.
 - Use `make logs` or service-specific logs to inspect errors.
 - If migrations fail, check Postgres health first.
 
 ## Deployment Notes
 - `infra/docker-compose.yml` is production-oriented and does not mount host source code into `app`, `celery_worker`, or `celery_beat`.
+- It also publishes **only** the Nginx port to the host; Postgres/Redis/RabbitMQ/app stay internal to `app-network`. If you genuinely need a backing port on the host in production, bind it to `127.0.0.1` (or restrict it via a `DOCKER-USER` firewall rule) — never the short `host:container` syntax, which binds `0.0.0.0` and bypasses UFW. See `docs/readme/security.md`.
 - Source bind mounts remain only in `infra/docker-compose.override.yml` for local development.
 - `infra/nginx/app.conf` sets baseline security headers at the reverse-proxy layer, while the FastAPI app keeps the same headers as a fallback for direct app access and tests.
 - `Strict-Transport-Security` is included in the template config, but it is only appropriate when clients actually use HTTPS end-to-end or via a trusted TLS-terminating proxy/load balancer.

--- a/docs/readme/security.md
+++ b/docs/readme/security.md
@@ -185,6 +185,52 @@ Nginx additionally sets `server_tokens off` (hides version) and `client_max_body
 
 **Why it matters:** Running as root inside a container means a container escape yields root on the host. Non-root execution, minimal images, and multi-stage builds reduce both the probability and impact of container compromise.
 
+## Host Port Exposure (Docker & UFW)
+
+`infra/docker-compose.yml`, `infra/docker-compose.override.yml`
+
+**Why UFW does not protect Docker-published ports:** the short port syntax
+`ports: "host:container"` binds `0.0.0.0` (all interfaces), and Docker inserts
+its own rules into the `DOCKER` iptables chain — which is evaluated *before* the
+`INPUT` chain that UFW manages. As a result, a `ufw deny <port>` rule has **no
+effect** on a container-published port: it is reachable from the internet even
+when UFW reports the port as blocked.
+
+**What the template does:**
+- The base (production) compose file publishes **only Nginx (`8000`)** to the
+  host. Postgres, Redis, RabbitMQ, and the app are no longer host-published —
+  they communicate over the internal `app-network` bridge by service name
+  (`postgres:5432`, `redis:6379`, `rabbitmq:5672`, `app:8001`), so they are
+  unreachable from outside the host regardless of firewall state.
+- The dev overlay (`docker-compose.override.yml`, local-only) re-exposes those
+  backing services bound to `127.0.0.1` for debugging and host-side integration
+  tests. Loopback binds are not reachable from the network, so the iptables
+  bypass does not apply.
+
+**The remaining public port (Nginx, `8000`):** this is the intended front door
+and is published on `0.0.0.0` by design. Because of the bypass above, UFW alone
+will not govern it. To make the firewall authoritative for this port, add a rule
+to the `DOCKER-USER` chain (Docker always evaluates `DOCKER-USER` first and
+preserves it across daemon restarts), e.g. allow only a trusted source:
+
+```bash
+iptables -I DOCKER-USER -p tcp --dport 8000 ! -s <trusted-cidr> -j DROP
+```
+
+Or use [`ufw-docker`](https://github.com/chaifeng/ufw-docker), which wires
+Docker traffic through UFW's `route` rules:
+
+```bash
+ufw-docker install
+ufw route allow proto tcp from any to any port 8000
+```
+
+**Why it matters:** publishing Postgres/Redis/RabbitMQ on `0.0.0.0` exposes
+unauthenticated-by-default data stores and the RabbitMQ management UI to the
+internet, silently bypassing the host firewall. Keeping backing services off the
+host and constraining the one public port via `DOCKER-USER`/`ufw-docker` closes
+that gap.
+
 ## Nginx Hardening
 
 `infra/nginx/app.conf`, `infra/nginx/main.conf`

--- a/infra/docker-compose.override.yml
+++ b/infra/docker-compose.override.yml
@@ -11,6 +11,11 @@ services:
     container_name: template-app
     image: template-app-dev-image:latest
     command: uvicorn src.main.web:app --host 0.0.0.0 --port ${APP_BACKEND_PORT} --reload
+    # Loopback-only: direct app access (bypassing Nginx) for local debugging.
+    # Never bind backing services to 0.0.0.0 — Docker writes the DOCKER iptables
+    # chain and would bypass UFW. See docs/readme/security.md.
+    ports:
+      - "127.0.0.1:${APP_BACKEND_PORT}:${APP_BACKEND_PORT}"
     volumes:
       - ..:/app
       - /app/.venv
@@ -30,3 +35,20 @@ services:
   nginx:
     volumes:
       - ./nginx/dev-nginx.conf:/etc/nginx/conf.d/default.conf
+
+  # Backing services are not published in the base (prod) compose file. Re-expose
+  # them here on 127.0.0.1 only, for local debugging and host-side integration
+  # tests (.env.test uses localhost). Loopback binds are not reachable from the
+  # network, so the Docker/UFW iptables bypass does not apply.
+  postgres:
+    ports:
+      - "127.0.0.1:${POSTGRES_PORT}:5432"
+
+  redis:
+    ports:
+      - "127.0.0.1:${REDIS_PORT}:6379"
+
+  rabbitmq:
+    ports:
+      - "127.0.0.1:${RABBITMQ_PORT}:5672"
+      - "127.0.0.1:15672:15672"

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -30,8 +30,6 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_DB: ${POSTGRES_DB}
       PGDATA: /var/lib/postgresql/18/main
-    ports:
-      - "${POSTGRES_PORT}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql
       - ./postgres/postgresql.conf:/custom-config/postgresql.conf:ro
@@ -54,8 +52,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    ports:
-      - "${APP_BACKEND_PORT}:${APP_BACKEND_PORT}"
     depends_on:
       postgres:
         condition: service_healthy
@@ -144,8 +140,6 @@ services:
       timeout: 3s
       retries: 5
     command: redis-server /etc/redis/redis.conf --requirepass ${REDIS_PASSWORD}
-    ports:
-      - "${REDIS_PORT}:6379"
     volumes:
       - ./redis.conf:/etc/redis/redis.conf:ro
       - redis-data:/data
@@ -170,9 +164,6 @@ services:
     environment:
       - RABBITMQ_DEFAULT_USER=${RABBITMQ_USER}
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_PASSWORD}
-    ports:
-      - "${RABBITMQ_PORT}:5672"
-      - "15672:15672"
     networks:
       - app-network
     deploy:

--- a/src/core/email_service/templates/base.html
+++ b/src/core/email_service/templates/base.html
@@ -49,7 +49,6 @@
     />
   </head>
   <body style="margin: 0; padding: 0; min-width: 100%; background-color: #f0f1f3">
-  {{ self }}
     <center style="width: 100%; table-layout: fixed; background-color: #f0f1f3">
       <div
         style="

--- a/tests/unit/src/core/email_service/test_email_templates.py
+++ b/tests/unit/src/core/email_service/test_email_templates.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+TEMPLATE_DIR = Path("src/core/email_service/templates")
+
+
+def build_template_environment() -> Environment:
+    return Environment(
+        loader=FileSystemLoader(TEMPLATE_DIR),
+        autoescape=select_autoescape(["html"]),
+    )
+
+
+def test_email_template_does_not_render_template_reference() -> None:
+    environment = build_template_environment()
+
+    html = environment.get_template("notification.html").render(
+        title="Notification",
+        message="Hello",
+        logo_url="https://example.com/logo.png",
+        year=2026,
+    )
+
+    assert "TemplateReference" not in html


### PR DESCRIPTION
---

### Description

This pull request refactors the Docker Compose configuration to remove unnecessary host port bindings that bypass UFW (Uncomplicated Firewall) rules and resolves issues related to network security. It also includes documentation updates to address these changes and improve security guidelines.

**Key Changes:**
- Removed `ports:` mappings from PostgreSQL, Redis, RabbitMQ, and the app in the base Compose file to prevent exposure of these services to the internet.
- Retained `ports:` mappings locally (bound to `127.0.0.1`) for development and integration tests through a development-specific override.
- Documented the Docker/UFW bypass issue, provided guidance on mitigating it for the public-facing Nginx port, and synchronized port tables across `infra.md` and the `README.md`.
- Removed unused `self` block from email templates.
- Enhanced CI permissions guidance and security documentation in the `README.md`.
