### PR TITLE
chore: harden infra defaults, test init and migration config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,18 @@ __pycache__/
 .venv
 *.log
 .git
+
+# Runtime code only: tests run on the host, so keep dev tooling, tests, docs,
+# caches and the test env file out of the image.
+.env.test
+.idea/
+.vscode/
+.claude/
+tests/
+docs/
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+coverage.xml
+.coverage
+htmlcov/

--- a/alembic.ini
+++ b/alembic.ini
@@ -9,7 +9,7 @@ script_location = migrations
 # Uncomment the line below if you want the files to be prepended with date and time
 # see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
 # for all available tokens
-# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
 
 # sys.path path, will be prepended to sys.path if present.
 # defaults to the current working directory.

--- a/docs/readme/infra.md
+++ b/docs/readme/infra.md
@@ -37,7 +37,6 @@ Configs live in `infra/` (compose, nginx, dockerfiles, redis/postgres, requireme
 ## Quick Start
 ```bash
 cp .env.example .env   # main env
-cp .env.test .env.test # optional test env (used when TESTING=true)
 make run-dev          # dev images + autoreload, exposes 8000 via nginx
 # or:
 make run              # prod-like build
@@ -89,4 +88,4 @@ make clean            # remove stack + volumes/images/orphans
 - TLS terminates at Nginx: copy `infra/nginx/tls.conf.example` over the `app.conf` mount, put the certificate under `infra/nginx/certs/` (git-ignored) and set the real hostname. It redirects plain http to https and leaves the ACME challenge path reachable.
 - `Strict-Transport-Security` comes from the application, not from Nginx — one header, one source. It is only appropriate once clients actually reach the site over HTTPS end to end.
 - `infra/firewall/` closes the host: UFW for host listeners plus a `DOCKER-USER` chain for container traffic, installed as a systemd unit. Run `sudo bash harden-host.sh` on the server; see `infra/firewall/README.md`.
-- `client_max_body_size 10m` is the current default. Increase it deliberately if the project introduces larger upload scenarios.
+- `client_max_body_size 20m` is the current default, kept in sync with `S3_MAX_UPLOAD_SIZE_BYTES`. Change both together if the project needs larger uploads.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       dockerfile: infra/postgres/Dockerfile
     image: template-postgres:18
     restart: always
+    shm_size: 256m
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s
@@ -46,7 +47,8 @@ services:
     image: template-app-image:latest
     env_file: ../.env
     command: gunicorn -k uvicorn.workers.UvicornWorker -w 4 -b 0.0.0.0:${APP_BACKEND_PORT} --worker-connections 1000 --keep-alive 10 src.main.web:app
-    restart: on-failure
+    restart: unless-stopped
+    stop_grace_period: 35s
     healthcheck:
       test: ["CMD", "wget", "--spider", "http://0.0.0.0:${APP_BACKEND_PORT}/health/"]
       interval: 10s
@@ -73,6 +75,7 @@ services:
     # in src/core/database/engine.py - change both together.
     command: taskiq worker taskiq_worker.app:broker --receiver taskiq_worker.receiver:IdempotencyReceiver --max-async-tasks 20
     restart: unless-stopped
+    stop_grace_period: 35s
     depends_on:
       postgres:
         condition: service_healthy
@@ -142,7 +145,9 @@ services:
     restart: unless-stopped
     env_file: ../.env
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      # Plain `redis-cli ping` exits 0 even on NOAUTH under requirepass, so a
+      # broken instance reads as healthy; authenticate and assert the PONG.
+      test: ["CMD-SHELL", "redis-cli -a \"$$REDIS_PASSWORD\" --no-auth-warning ping | grep -q PONG"]
       interval: 10s
       timeout: 3s
       retries: 5

--- a/infra/nginx/app.conf
+++ b/infra/nginx/app.conf
@@ -7,7 +7,7 @@ server {
     listen 80;
     server_name _;
     server_tokens off;
-    client_max_body_size 10m;
+    client_max_body_size 20m;  # keep in sync with S3_MAX_UPLOAD_SIZE_BYTES (default 20MB)
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/infra/nginx/tls.conf.example
+++ b/infra/nginx/tls.conf.example
@@ -1,10 +1,13 @@
 # Drop-in replacement for app.conf once the host has a certificate.
 #
 # 1. Put the certificate and key under infra/nginx/certs/ (git-ignored).
-# 2. In infra/docker-compose.yml, mount this file instead of app.conf and add
-#    the certs directory:
-#      - ./nginx/tls.conf.example:/etc/nginx/conf.d/app.conf:ro
+# 2. In infra/docker-compose.yml, mount this file OVER the app.conf mount - the
+#    same /etc/nginx/conf.d/default.conf target app.conf uses, otherwise the
+#    plain-http app.conf stays active alongside it - and add the certs plus the
+#    ACME webroot (a volume shared with certbot so it can write challenges):
+#      - ./nginx/tls.conf.example:/etc/nginx/conf.d/default.conf:ro
 #      - ./nginx/certs:/etc/nginx/certs:ro
+#      - certbot-webroot:/var/www/certbot:ro
 # 3. Replace api.example.com below with the real hostname.
 #
 # The proxy body lives in proxy.inc, the same file app.conf includes, so the two
@@ -35,7 +38,7 @@ server {
     http2 on;
     server_name api.example.com;
     server_tokens off;
-    client_max_body_size 10m;
+    client_max_body_size 20m;  # keep in sync with S3_MAX_UPLOAD_SIZE_BYTES (default 20MB)
 
     ssl_certificate /etc/nginx/certs/fullchain.pem;
     ssl_certificate_key /etc/nginx/certs/privkey.pem;

--- a/infra/postgres/postgresql.conf
+++ b/infra/postgres/postgresql.conf
@@ -6,10 +6,12 @@ listen_addresses = '*'
 # ---------------------------
 # RESOURCE USAGE (MEMORY)
 # ---------------------------
-shared_buffers = 1GB
+# Sized for the 1G container memory limit in docker-compose.yml; raise these and
+# shm_size there together when raising that limit.
+shared_buffers = 256MB
 work_mem = 16MB
 maintenance_work_mem = 128MB
-effective_cache_size = 2GB
+effective_cache_size = 768MB
 
 # ---------------------------
 # WAL (WRITE-AHEAD LOG)

--- a/infra/redis.conf
+++ b/infra/redis.conf
@@ -13,3 +13,9 @@ dir /data
 # sharing this instance.
 appendonly yes
 appendfsync everysec
+
+# Cap well under the 1G container limit so an RDB/AOF-rewrite fork has headroom
+# and cannot OOM-kill the instance. noeviction because this is a shared
+# cache+queue: refuse writes rather than silently drop queued taskiq messages.
+maxmemory 512mb
+maxmemory-policy noeviction

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -53,6 +53,7 @@ def do_run_migrations(connection: Connection) -> None:
     context.configure(
         connection=connection,
         target_metadata=target_metadata,
+        compare_server_default=True,
     )
 
     with context.begin_transaction():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
-from collections.abc import AsyncGenerator, Generator
+# ruff: noqa: E402 -- TESTING must be set before any src.* import triggers config load
 import os
+
+os.environ.setdefault("TESTING", "true")
+
+from collections.abc import AsyncGenerator, Generator
 from unittest.mock import AsyncMock
 
 from fastapi import FastAPI
@@ -24,7 +28,6 @@ from tests.helpers.providers import ProvideAsyncValue, ProvideValue
 
 @pytest.fixture(scope="session")
 def settings() -> Config:
-    os.environ.setdefault("TESTING", "true")
     get_settings.cache_clear()
     return get_settings()
 

--- a/tests/unit/test_nginx_security_config.py
+++ b/tests/unit/test_nginx_security_config.py
@@ -14,7 +14,7 @@ def test_nginx_app_config_includes_security_headers_and_body_limit() -> None:
     app_conf = _read("app.conf")
 
     assert "server_tokens off;" in app_conf
-    assert "client_max_body_size 10m;" in app_conf
+    assert "client_max_body_size 20m;" in app_conf
     assert 'add_header X-Content-Type-Options "nosniff" always;' in app_conf
     assert 'add_header X-Frame-Options "DENY" always;' in app_conf
     assert "add_header Content-Security-Policy" not in app_conf


### PR DESCRIPTION
## What / why

Batch of safe, mechanical infra/config/test hardening. Each fix removes a default footgun a fresh fork would otherwise inherit.

- **Postgres OOM:** `shared_buffers`/`effective_cache_size`/`shm_size` now sized against the 1G container limit instead of exceeding it.
- **Compose resilience:** `restart: unless-stopped` + `stop_grace_period: 35s` on app/worker (survives host reboot, drains in-flight requests); the redis healthcheck now authenticates and asserts `PONG` instead of passing on `NOAUTH`.
- **Redis:** `maxmemory 512mb` + `noeviction` so the shared cache/queue instance refuses writes rather than dropping queued tasks.
- **Image hygiene:** `.dockerignore` keeps tests, docs and dev tooling out of the prod image.
- **Nginx:** `client_max_body_size` aligned with `S3_MAX_UPLOAD_SIZE_BYTES` (20m); `tls.conf.example` mount target and ACME webroot fixed.
- **Test init:** `conftest` sets `TESTING` before any `src` import, so bare `pytest` uses the test config.
- **Alembic:** `compare_server_default=True` and date-prefixed migration filenames.

## Testing

`make lint` clean, nginx config tests pass, full suite green (438). No app code touched.

## Config/env

No new env keys; `client_max_body_size` default changed 10m to 20m.