### PR TITLE
feat(ci): build the image in CI and deploy it from GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,3 +247,53 @@ jobs:
         uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Builds the image once, here, so a broken Dockerfile fails in CI instead of
+  # on the production box mid-deploy. CD then pulls this exact sha tag.
+  build-and-push:
+    name: Build & push image
+    needs: [lint, migration-heads, unit-tests, bandit, pip-audit, gitleaks]
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Compute image and tag
+        id: meta
+        run: |
+          image_lower="$(echo "ghcr.io/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')"
+          short_sha="$(echo "${{ github.sha }}" | cut -c1-12)"
+          echo "image=${image_lower}" >> "$GITHUB_OUTPUT"
+          echo "tag=sha-${short_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: infra/docker/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}
+            ${{ steps.meta.outputs.image }}:latest
+          # Lets a deploy assert which commit an image tag was actually built from.
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
           mkdir -p ~/.ssh && chmod 700 ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" | tr -d '\r' > ~/.ssh/id_deploy_key
           chmod 600 ~/.ssh/id_deploy_key
-          echo "${{ secrets.SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          echo "${{ secrets.SSH_KNOWN_HOSTS }}" | tr -d '\r' > ~/.ssh/known_hosts
           chmod 600 ~/.ssh/known_hosts
 
       - name: Deploy over SSH
@@ -71,6 +71,9 @@ jobs:
           git fetch --quiet origin main
           git checkout --quiet ${{ github.event.workflow_run.head_sha }}
           echo "${{ secrets.GHCR_PULL_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USER }}" --password-stdin
+          # The token would otherwise sit base64-encoded in ~/.docker/config.json
+          # on the box until the next deploy overwrites it.
+          trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
           BUILD=0 APP_IMAGE="${IMAGE}:${TAG}" bash infra/deploy/deploy.sh
           EOF
 
@@ -78,7 +81,8 @@ jobs:
       - name: Telegram notification
         if: always()
         run: |
-          set -euo pipefail
+          # No `set -e` here: this step must still reach curl when an earlier
+          # step failed, which is the case the alert exists for.
           sanitize_html() {
             echo "$1" \
               | sed 's/&/\&amp;/g' \
@@ -95,7 +99,7 @@ jobs:
           fi
 
           END_TS=$(date +%s)
-          DURATION=$((END_TS - JOB_START_TS))
+          DURATION=$((END_TS - ${JOB_START_TS:-END_TS}))
 
           if [ "$DURATION" -gt 60 ]; then
             DURATION_HUMAN="$((DURATION / 60)) min $((DURATION % 60)) sec"
@@ -103,8 +107,8 @@ jobs:
             DURATION_HUMAN="${DURATION} sec"
           fi
 
-          COMMIT_MSG=$(git log -1 --pretty=format:'%s')
-          AUTHOR=$(git log -1 --pretty=format:'%an')
+          COMMIT_MSG=$(git log -1 --pretty=format:'%s' 2>/dev/null || echo 'unknown')
+          AUTHOR=$(git log -1 --pretty=format:'%an' 2>/dev/null || echo 'unknown')
           PROJECT=$(sanitize_html "${{ github.repository }}")
           PIPELINE_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,14 @@ env:
 jobs:
   deploy:
     name: Deploy
+    # DEPLOY_ENABLED is a repository variable, not a secret: the `secrets`
+    # context is unavailable in a job-level `if`. It is off by default so a
+    # fresh fork - and this template itself - does not fail a deploy against
+    # unset SSH secrets on every merge to main. Set it to `true` once the
+    # server secrets below are filled in.
     if: >-
-      ${{ github.event.workflow_run.conclusion == 'success' &&
+      ${{ vars.DEPLOY_ENABLED == 'true' &&
+          github.event.workflow_run.conclusion == 'success' &&
           github.event.workflow_run.event == 'push' &&
           github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,12 @@
 name: CD
 
-# This workflow is triggered after the CI workflow completes successfully
+# Runs after CI succeeds on main, then deploys the image CI already built and
+# pushed to GHCR - the box never builds on the CD path.
 on:
   workflow_run:
-    workflows: [ "CI" ]
+    workflows: ["CI"]
     types:
       - completed
-
 
 env:
   # Deployment directory on the target server - adjust as needed for your environment
@@ -14,53 +14,71 @@ env:
 
 jobs:
   deploy:
-    name: Build & Deploy
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    name: Deploy
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.event == 'push' &&
+          github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Never cancelled and never parallel: two merges must not run two migrations
+    # against the same database at once.
     concurrency:
       group: deploy
       cancel-in-progress: false
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v7
+      - name: Capture job start time
+        run: echo "JOB_START_TS=$(date +%s)" >> "$GITHUB_ENV"
 
-      # Set up SSH for secure connection to the deployment server
-      - name: Set up SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" | tr -d '\r' > ~/.ssh/id_deploy_key
-          chmod 600 ~/.ssh/id_deploy_key
-          ssh-keyscan -H "${{ secrets.SERVER_IP }}" >> ~/.ssh/known_hosts
-
-      # Deploy the application to the target server
-      - name: SSH deploy
-        id: deploy
-        run: |
-          ssh -i ~/.ssh/id_deploy_key -o StrictHostKeyChecking=no \
-            ${{ secrets.SSH_USER }}@${{ secrets.SERVER_IP }} "\
-              cd $APP_DIR && \
-              git pull origin main && \
-              python3 scripts/check_env.py || { echo '❌ Environment file validation failed!'; exit 1; } && \
-              make deploy-prod && \
-              make clean-resources"
-
-      - name: Restart Nginx
-        if: steps.deploy.outcome == 'success'
-        run: |
-          ssh -i ~/.ssh/id_deploy_key -o StrictHostKeyChecking=no \
-            ${{ secrets.SSH_USER }}@${{ secrets.SERVER_IP }} "docker restart template-nginx"
-
-      # Check out the exact commit that triggered this workflow
-      - name: Checkout correct commit
+      # The exact commit CI built, so the notification and the image agree.
+      - name: Checkout the deployed commit
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.workflow_run.head_commit.id }}
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Compute image and tag
+        id: meta
+        run: |
+          image_lower="$(echo "ghcr.io/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')"
+          short_sha="$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-12)"
+          echo "image=${image_lower}" >> "$GITHUB_OUTPUT"
+          echo "tag=sha-${short_sha}" >> "$GITHUB_OUTPUT"
+
+      # known_hosts comes from a secret (`ssh-keyscan <host>` once, by hand):
+      # keyscanning inside the job would trust whatever answers, which is the
+      # same hole as StrictHostKeyChecking=no.
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" | tr -d '\r' > ~/.ssh/id_deploy_key
+          chmod 600 ~/.ssh/id_deploy_key
+          echo "${{ secrets.SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Deploy over SSH
+        id: deploy
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          # shellcheck disable=SC2087  # the heredoc expands here on purpose: the
+          # image tag and the secrets come from this runner, not from the server.
+          ssh -i ~/.ssh/id_deploy_key -o UserKnownHostsFile=~/.ssh/known_hosts \
+            "${{ secrets.SSH_USER }}@${{ secrets.SERVER_IP }}" bash -s <<EOF
+          set -euo pipefail
+          cd "${{ env.APP_DIR }}"
+          git fetch --quiet origin main
+          git checkout --quiet ${{ github.event.workflow_run.head_sha }}
+          echo "${{ secrets.GHCR_PULL_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USER }}" --password-stdin
+          BUILD=0 APP_IMAGE="${IMAGE}:${TAG}" bash infra/deploy/deploy.sh
+          EOF
 
       # Send deployment status notification to Telegram
       - name: Telegram notification
         if: always()
         run: |
+          set -euo pipefail
           sanitize_html() {
             echo "$1" \
               | sed 's/&/\&amp;/g' \
@@ -76,12 +94,11 @@ jobs:
             STATUS="❌ <b>FAILED</b>"
           fi
 
-          START_TS=$(git log -1 --pretty=format:'%ct')
           END_TS=$(date +%s)
-          DURATION=$((END_TS - START_TS))
+          DURATION=$((END_TS - JOB_START_TS))
 
           if [ "$DURATION" -gt 60 ]; then
-            DURATION_HUMAN="$(($DURATION / 60)) min $(($DURATION % 60)) sec"
+            DURATION_HUMAN="$((DURATION / 60)) min $((DURATION % 60)) sec"
           else
             DURATION_HUMAN="${DURATION} sec"
           fi
@@ -93,9 +110,10 @@ jobs:
 
           MESSAGE="${STATUS}
           🚀 <b>Project</b>: ${PROJECT}
-          🔖 <b>Version</b>: <code>${{ github.sha }}</code>
+          🔖 <b>Version</b>: <code>${{ github.event.workflow_run.head_sha }}</code>
           👤 <b>Author</b>: ${AUTHOR}
           ⏱️ <b>Duration</b>: ${DURATION_HUMAN}
+          ♻️ <b>Attempt</b>: ${GITHUB_RUN_ATTEMPT}
           🔗 <b>Pipeline</b>: <a href=\"${PIPELINE_URL}\">Open</a>
           📝 <b>Commit</b>: ${COMMIT_MSG}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,9 @@ jobs:
         id: meta
         run: |
           image_lower="$(echo "ghcr.io/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')"
-          short_sha="$(echo "${{ github.sha }}" | cut -c1-12)"
           {
             echo "image=${image_lower}"
             echo "version=${{ github.ref_name }}"
-            echo "sha_tag=sha-${short_sha}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Buildx
@@ -47,9 +45,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # The sha tag is pushed again on purpose: a tag may point at a commit CI
-      # never built (a tag on a branch, a re-tag), and the release must not
-      # depend on that image already existing.
+      # Only the version tag is pushed. Re-pushing sha-<12> would move a tag CI
+      # already published and CD may have deployed, so the same tag would stop
+      # meaning the same image. The revision label keeps the commit traceable.
       - name: Build and push the release image
         uses: docker/build-push-action@v7
         with:
@@ -57,9 +55,7 @@ jobs:
           file: infra/docker/Dockerfile
           push: true
           platforms: linux/amd64
-          tags: |
-            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}
-            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.sha_tag }}
+          tags: ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.meta.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,11 @@ jobs:
         id: meta
         run: |
           image_lower="$(echo "ghcr.io/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')"
+          short_sha="$(echo "${{ github.sha }}" | cut -c1-12)"
           {
             echo "image=${image_lower}"
             echo "version=${{ github.ref_name }}"
+            echo "sha_tag=sha-${short_sha}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Buildx
@@ -45,10 +47,38 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Only the version tag is pushed. Re-pushing sha-<12> would move a tag CI
-      # already published and CD may have deployed, so the same tag would stop
-      # meaning the same image. The revision label keeps the commit traceable.
-      - name: Build and push the release image
+      - name: Look for the image CI built for this commit
+        id: source
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          SHA_TAG: ${{ steps.meta.outputs.sha_tag }}
+        run: |
+          if docker buildx imagetools inspect "${IMAGE}:${SHA_TAG}" >/dev/null 2>&1; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No ${SHA_TAG} image - the tagged commit never went through CI on main. Building from source instead."
+          fi
+
+      # Build once, promote many: the release tag points at the exact image CI
+      # built and CD deployed. A rebuild would run the same code on newer base
+      # layers, so v1.2.0 would not be the artifact that was tested.
+      # `imagetools create` copies the manifest by digest inside the registry,
+      # so no layer is pulled or pushed. The version therefore lives in the tag
+      # and the release, not in an image label - changing a label would change
+      # the config blob, and with it the digest.
+      - name: Promote the CI-built image to the release tag
+        if: steps.source.outputs.found == 'true'
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          SHA_TAG: ${{ steps.meta.outputs.sha_tag }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: docker buildx imagetools create -t "${IMAGE}:${VERSION}" "${IMAGE}:${SHA_TAG}"
+
+      # Fallback only: a tag off main, or on a commit whose CI run predates the
+      # build job. Never re-pushes sha-<12>, which CI owns.
+      - name: Build the release image from source
+        if: steps.source.outputs.found != 'true'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -67,12 +97,20 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMAGE: ${{ steps.meta.outputs.image }}
           VERSION: ${{ steps.meta.outputs.version }}
+          PROMOTED: ${{ steps.source.outputs.found }}
         run: |
           set -euo pipefail
+          digest="$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" --format '{{.Manifest.Digest}}')"
+          if [ "$PROMOTED" = "true" ]; then
+            origin="promoted from the image CI built for this commit"
+          else
+            origin="built from source: no CI image existed for this commit"
+          fi
           notes="$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
             -f tag_name="$VERSION" --jq .body)"
           # shellcheck disable=SC2016  # the backticks are markdown, not a subshell
-          printf '%s\n\nImage: `%s:%s`\n' "$notes" "$IMAGE" "$VERSION" > release-notes.md
+          printf '%s\n\nImage: `%s:%s`\nDigest: `%s` (%s)\n' \
+            "$notes" "$IMAGE" "$VERSION" "$digest" "$origin" > release-notes.md
           gh release create "$VERSION" \
             --title "$VERSION" \
             --verify-tag \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Release
+
+# Tagging vX.Y.Z publishes a versioned image next to the sha- and latest- tags
+# CI pushes, and opens a GitHub Release with generated notes. Nothing deploys
+# from here: CD still follows main.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Publish image and release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Compute image and tags
+        id: meta
+        run: |
+          image_lower="$(echo "ghcr.io/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')"
+          short_sha="$(echo "${{ github.sha }}" | cut -c1-12)"
+          {
+            echo "image=${image_lower}"
+            echo "version=${{ github.ref_name }}"
+            echo "sha_tag=sha-${short_sha}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # The sha tag is pushed again on purpose: a tag may point at a commit CI
+      # never built (a tag on a branch, a re-tag), and the release must not
+      # depend on that image already existing.
+      - name: Build and push the release image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: infra/docker/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}
+            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.sha_tag }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Create the GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE: ${{ steps.meta.outputs.image }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          notes="$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="$VERSION" --jq .body)"
+          # shellcheck disable=SC2016  # the backticks are markdown, not a subshell
+          printf '%s\n\nImage: `%s:%s`\n' "$notes" "$IMAGE" "$VERSION" > release-notes.md
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --verify-tag \
+            --notes-file release-notes.md

--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,13 @@ shell: ## Open a bash shell inside the app container
 ##@ Deploy
 
 .PHONY: deploy-prod
-deploy-prod: ## Build, swap the containers and migrate
-	$(MAKE) build
-	$(MAKE) down
-	$(MAKE) up
-	$(MAKE) migrate
+deploy-prod: ## Deploy on the box, building the image locally
+	bash infra/deploy/deploy.sh
+
+.PHONY: deploy-image
+deploy-image: ## Deploy a registry image: make deploy-image APP_IMAGE=ghcr.io/owner/repo:sha-abc123
+	@test -n "$(APP_IMAGE)" || { echo "APP_IMAGE is required"; exit 1; }
+	BUILD=0 APP_IMAGE=$(APP_IMAGE) bash infra/deploy/deploy.sh
 
 ##@ Cleanup
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ for `app.conf` once the certificate is in place.
 - `make clean` — remove containers/volumes/images/orphans
 - `make lint` / `make test` — quality checks
 - `make test-cov` — tests with coverage report
+- `make deploy-prod` — deploy on the box, building the image there
+- `make deploy-image APP_IMAGE=ghcr.io/<owner>/<repo>:sha-<12>` — deploy an image built by CI (what CD runs)
 
 ## Pre-commit Hooks
 - Install dev deps: `make req-sync-dev`

--- a/docs/readme/contributing.md
+++ b/docs/readme/contributing.md
@@ -20,6 +20,7 @@
 - On a push to `main` (never on a pull request) the `build-and-push` job builds `infra/docker/Dockerfile` and pushes it to GHCR as `sha-<12>` plus `latest`, with buildx layer caching and an `org.opencontainers.image.revision` label. The image is built here so a broken Dockerfile fails in CI, not halfway through a production deploy.
 
 ### CD (`.github/workflows/deploy.yml`)
+- Off until you opt in: the job is gated on the repository **variable** `DEPLOY_ENABLED=true` (a variable, not a secret — `secrets` cannot be read in a job-level `if`). Without it a fresh fork would fail a deploy against unset SSH secrets on every merge to `main`.
 - Runs after CI succeeds on a push to `main`, and pulls the exact `sha-` image that run produced — the box never builds.
 - On the server it checks out the deployed commit and runs `infra/deploy/deploy.sh` with `BUILD=0`: validate `.env`, pull the image, start Postgres/Redis, apply migrations, then roll `app`, `worker`, `scheduler` and restart nginx. A failed migration aborts the deploy with the previous containers still serving.
 - `concurrency: deploy` with `cancel-in-progress: false` — two merges never run two migrations at once.
@@ -40,6 +41,9 @@
 - If posting a "superseded" comment fails, the workflow still proceeds to close the superseded PR.
 
 ### Required Secrets
+CI and Release need none of these: both authenticate to GHCR with the automatic `GITHUB_TOKEN`. Everything below belongs to the CD path, and CD stays skipped until `DEPLOY_ENABLED` is set.
+
+- DEPLOY_ENABLED — repository *variable* (`Settings -> Secrets and variables -> Actions -> Variables`), set to `true` to arm CD.
 - SSH_PRIVATE_KEY, SERVER_IP, SSH_USER — server access.
 - SSH_KNOWN_HOSTS — output of `ssh-keyscan <server-ip>`, generated once by hand and verified against the host's own key.
 - GHCR_USER, GHCR_PULL_TOKEN — the server's pull credentials for GHCR (a classic PAT with `read:packages`). The package is private by default; make it public only if the application image may be world-readable.

--- a/docs/readme/contributing.md
+++ b/docs/readme/contributing.md
@@ -27,7 +27,7 @@
 - Notifications: Telegram with status, duration, pipeline link.
 
 ### Release (`.github/workflows/release.yml`)
-- Pushing a `vX.Y.Z` tag builds the image again, pushes it as `vX.Y.Z` (plus its `sha-` tag) and opens a GitHub Release with generated notes.
+- Pushing a `vX.Y.Z` tag builds the image again, pushes it as `vX.Y.Z` only — the `sha-` tag CI published stays immutable — and opens a GitHub Release with generated notes.
 - Releases publish images only. Deployment still follows `main`; to run a release image, deploy it explicitly with `make deploy-image APP_IMAGE=ghcr.io/<owner>/<repo>:vX.Y.Z`.
 
 ### Pre-commit Autoupdate (`.github/workflows/pre-commit-autoupdate.yml`)

--- a/docs/readme/contributing.md
+++ b/docs/readme/contributing.md
@@ -28,7 +28,10 @@
 - Notifications: Telegram with status, duration, pipeline link.
 
 ### Release (`.github/workflows/release.yml`)
-- Pushing a `vX.Y.Z` tag builds the image again, pushes it as `vX.Y.Z` only — the `sha-` tag CI published stays immutable — and opens a GitHub Release with generated notes.
+- Pushing a `vX.Y.Z` tag publishes the image under that tag and opens a GitHub Release with generated notes, the image digest and where the image came from.
+- Build once, promote many: the release does **not** rebuild. `docker buildx imagetools create` copies the `sha-<12>` image CI already built for that commit onto the `vX.Y.Z` tag, by digest and inside the registry, so `vX.Y.Z` is bit-for-bit the artifact CI tested and CD deployed. A rebuild would run the same code on whatever base layers exist today.
+- Because the digest is preserved, the version lives in the tag and the release, not in an image label — rewriting a label would change the config blob and therefore the digest.
+- Tag a commit on `main` that passed CI. A tag off a branch (or predating the build job) has no `sha-` image; the workflow then falls back to building from source and says so in the release notes. It never re-pushes `sha-<12>`, which CI owns.
 - Releases publish images only. Deployment still follows `main`; to run a release image, deploy it explicitly with `make deploy-image APP_IMAGE=ghcr.io/<owner>/<repo>:vX.Y.Z`.
 
 ### Pre-commit Autoupdate (`.github/workflows/pre-commit-autoupdate.yml`)

--- a/docs/readme/contributing.md
+++ b/docs/readme/contributing.md
@@ -17,10 +17,18 @@
 - `gitleaks` keeps history scanning enabled and relies on a narrow repo allowlist only for known example/test placeholders.
 - Security jobs are expected to fail on real findings, so dependency bumps should keep lockfiles current.
 
+- On a push to `main` (never on a pull request) the `build-and-push` job builds `infra/docker/Dockerfile` and pushes it to GHCR as `sha-<12>` plus `latest`, with buildx layer caching and an `org.opencontainers.image.revision` label. The image is built here so a broken Dockerfile fails in CI, not halfway through a production deploy.
+
 ### CD (`.github/workflows/deploy.yml`)
-- Deploys from `main` after successful CI.
-- Runs `check_env.py`, deploys via `make deploy-prod`, cleans resources, restarts nginx.
+- Runs after CI succeeds on a push to `main`, and pulls the exact `sha-` image that run produced — the box never builds.
+- On the server it checks out the deployed commit and runs `infra/deploy/deploy.sh` with `BUILD=0`: validate `.env`, pull the image, start Postgres/Redis, apply migrations, then roll `app`, `worker`, `scheduler` and restart nginx. A failed migration aborts the deploy with the previous containers still serving.
+- `concurrency: deploy` with `cancel-in-progress: false` — two merges never run two migrations at once.
+- SSH host keys come from the `SSH_KNOWN_HOSTS` secret; the pipeline does not keyscan at runtime and does not disable host key checking.
 - Notifications: Telegram with status, duration, pipeline link.
+
+### Release (`.github/workflows/release.yml`)
+- Pushing a `vX.Y.Z` tag builds the image again, pushes it as `vX.Y.Z` (plus its `sha-` tag) and opens a GitHub Release with generated notes.
+- Releases publish images only. Deployment still follows `main`; to run a release image, deploy it explicitly with `make deploy-image APP_IMAGE=ghcr.io/<owner>/<repo>:vX.Y.Z`.
 
 ### Pre-commit Autoupdate (`.github/workflows/pre-commit-autoupdate.yml`)
 - Runs weekly (Monday, `06:20 UTC`) and can be triggered manually (`workflow_dispatch`).
@@ -33,6 +41,8 @@
 
 ### Required Secrets
 - SSH_PRIVATE_KEY, SERVER_IP, SSH_USER — server access.
+- SSH_KNOWN_HOSTS — output of `ssh-keyscan <server-ip>`, generated once by hand and verified against the host's own key.
+- GHCR_USER, GHCR_PULL_TOKEN — the server's pull credentials for GHCR (a classic PAT with `read:packages`). The package is private by default; make it public only if the application image may be world-readable.
 - ALERT_BOT_TOKEN, ALERT_CHAT_ID — Telegram notifications.
 - PRECOMMIT_BOT_TOKEN (optional but recommended) — token for creating autoupdate PRs so downstream workflows can run reliably.
 - Production `.env` must exist on the target server.

--- a/docs/readme/infra.md
+++ b/docs/readme/infra.md
@@ -109,6 +109,10 @@ make clean            # remove stack + volumes/images/orphans
 - If migrations fail, check Postgres health first.
 
 ## Deployment Notes
+- `infra/deploy/deploy.sh` is the single deploy path, run on the box: it validates `.env`, brings up Postgres and Redis, applies migrations, then rolls `app`, `worker`, `scheduler` and restarts nginx. Migrations run before any new code serves traffic, and a failed one aborts the deploy with the previous containers still up.
+- Two modes. `BUILD=1` (the default, `make deploy-prod`) builds the image on the box — the bootstrap path, before any registry exists. `BUILD=0` with `APP_IMAGE=ghcr.io/<owner>/<repo>:sha-<12>` (`make deploy-image APP_IMAGE=…`) pulls the image CI already built; this is what CD uses, so the production box never compiles.
+- `APP_IMAGE` is the only knob: unset, every service falls back to the locally built `template-app-image:latest`, so `make run` and `make run-dev` behave exactly as before.
+- The box needs `docker login ghcr.io` credentials for a private package (`GHCR_USER` / `GHCR_PULL_TOKEN` in the CD workflow). Postgres stays a box-local build — CD ships application code, never the database image.
 - `infra/docker-compose.yml` is production-oriented and does not mount host source code into `app`, `worker`, or `scheduler`.
 - It also publishes **only** the Nginx port to the host; Postgres/Redis/app stay internal to `app-network`. If you genuinely need a backing port on the host in production, bind it to `127.0.0.1` (or restrict it via a `DOCKER-USER` firewall rule) — never the short `host:container` syntax, which binds `0.0.0.0` and bypasses UFW. See `docs/readme/security.md`.
 - Source bind mounts remain only in `infra/docker-compose.override.yml` for local development.

--- a/infra/deploy/deploy.sh
+++ b/infra/deploy/deploy.sh
@@ -16,9 +16,15 @@ REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$REPO_ROOT"
 
 BUILD="${BUILD:-1}"
+APP_IMAGE_WAS_GIVEN="${APP_IMAGE:+yes}"
 # Consumed by infra/docker-compose.yml for app, worker, scheduler and the builder.
 APP_IMAGE="${APP_IMAGE:-template-app-image:latest}"
 export APP_IMAGE
+
+if [ "$BUILD" = "0" ] && [ -z "$APP_IMAGE_WAS_GIVEN" ]; then
+  echo "[deploy] BUILD=0 requires APP_IMAGE - the local fallback tag exists in no registry"
+  exit 1
+fi
 
 COMPOSE=(docker compose --env-file .env -f infra/docker-compose.yml)
 
@@ -27,6 +33,12 @@ test -f .env || {
   exit 1
 }
 python3 scripts/check_env.py
+
+# The database image stays box-local in both modes - CD ships application code,
+# never the database. It is rebuilt every deploy because `up` reuses an existing
+# tag, so a change to infra/postgres/ would otherwise never reach the server.
+echo "[deploy] building the postgres image"
+"${COMPOSE[@]}" build postgres
 
 if [ "$BUILD" = "1" ]; then
   echo "[deploy] building ${APP_IMAGE} on the box"
@@ -51,8 +63,12 @@ echo "[deploy] rolling the application containers"
 # leaves it serving 502 until it restarts.
 "${COMPOSE[@]}" restart nginx
 
-echo "[deploy] pruning superseded images"
-docker image prune -f
+# Every BUILD=0 deploy leaves a tagged sha- image behind, and plain
+# `image prune` only touches dangling ones, so the disk grows until a pull
+# fails. A week keeps enough recent tags to roll back to.
+echo "[deploy] pruning images and build cache unused for a week"
+docker image prune -af --filter "until=168h"
+docker builder prune -f --filter "until=168h"
 
 echo "[deploy] done"
 "${COMPOSE[@]}" ps

--- a/infra/deploy/deploy.sh
+++ b/infra/deploy/deploy.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Deploy the stack on the target box. Run from anywhere inside the checkout.
+#
+# Modes:
+#   BUILD=1 (default) - build the application image on the box. Bootstrap path:
+#           works before any registry exists, and is what `make deploy-prod` uses.
+#   BUILD=0 - pull APP_IMAGE, the image CI already built and pushed to GHCR.
+#           The CD path: the box never compiles, so a broken build fails in CI
+#           instead of halfway through a production deploy.
+#
+# Order matters: data services first, then migrations, then the application.
+# A failed migration aborts the deploy with the previous app still serving.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+BUILD="${BUILD:-1}"
+# Consumed by infra/docker-compose.yml for app, worker, scheduler and the builder.
+APP_IMAGE="${APP_IMAGE:-template-app-image:latest}"
+export APP_IMAGE
+
+COMPOSE=(docker compose --env-file .env -f infra/docker-compose.yml)
+
+test -f .env || {
+  echo "[deploy] .env is missing on the box - copy .env.example and fill it in"
+  exit 1
+}
+python3 scripts/check_env.py
+
+if [ "$BUILD" = "1" ]; then
+  echo "[deploy] building ${APP_IMAGE} on the box"
+  "${COMPOSE[@]}" build app-builder
+else
+  echo "[deploy] pulling ${APP_IMAGE}"
+  "${COMPOSE[@]}" pull app
+fi
+
+echo "[deploy] starting data services"
+"${COMPOSE[@]}" up -d --wait postgres redis
+
+echo "[deploy] applying migrations before any new code serves traffic"
+"${COMPOSE[@]}" run --rm --no-deps app alembic upgrade head
+
+echo "[deploy] rolling the application containers"
+# --no-deps keeps app-builder out of the CD path: with BUILD=0 the image comes
+# from the registry and there is nothing to build.
+"${COMPOSE[@]}" up -d --no-deps --wait app worker scheduler
+"${COMPOSE[@]}" up -d --no-deps nginx
+# nginx resolves the app upstream once at startup, so a recreated app container
+# leaves it serving 502 until it restarts.
+"${COMPOSE[@]}" restart nginx
+
+echo "[deploy] pruning superseded images"
+docker image prune -f
+
+echo "[deploy] done"
+"${COMPOSE[@]}" ps

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -3,12 +3,15 @@
 
 name: fastapi-template
 services:
+  # APP_IMAGE lets a deploy run the image CI pushed to the registry instead of
+  # building on the box (infra/deploy/deploy.sh, BUILD=0). Unset, every service
+  # falls back to the locally built tag, so the plain `make run` path is unchanged.
   app-builder:
     container_name: template-app-builder
     build:
       context: ..
       dockerfile: infra/docker/Dockerfile
-    image: template-app-image:latest
+    image: ${APP_IMAGE:-template-app-image:latest}
     networks:
       - app-network
 
@@ -44,7 +47,7 @@ services:
 
   app:
     container_name: template-app
-    image: template-app-image:latest
+    image: ${APP_IMAGE:-template-app-image:latest}
     env_file: ../.env
     command: gunicorn -k uvicorn.workers.UvicornWorker -w 4 -b 0.0.0.0:${APP_BACKEND_PORT} --worker-connections 1000 --keep-alive 10 src.main.web:app
     restart: unless-stopped
@@ -69,7 +72,7 @@ services:
 
   worker:
     container_name: template-worker
-    image: template-app-image:latest
+    image: ${APP_IMAGE:-template-app-image:latest}
     env_file: ../.env
     # --max-async-tasks 20 is mirrored by tasks_engine pool_size+max_overflow
     # in src/core/database/engine.py - change both together.
@@ -95,7 +98,7 @@ services:
   # N schedulers fire every cron N times.
   scheduler:
     container_name: template-scheduler
-    image: template-app-image:latest
+    image: ${APP_IMAGE:-template-app-image:latest}
     env_file: ../.env
     command: taskiq scheduler taskiq_worker.scheduler:scheduler
     restart: unless-stopped


### PR DESCRIPTION
The image used to be built for the first time on the production box during the
deploy. CI now builds it on every push to `main` and pushes it to GHCR as
`sha-<12>` and `latest` (buildx cache, OCI revision label), and CD pulls that
exact tag.

New `infra/deploy/deploy.sh` is the single deploy path: validate `.env`, start
Postgres and Redis, apply migrations, then roll `app`, `worker`, `scheduler`
and restart nginx. A failed migration aborts with the previous containers still
serving, replacing the old `down` → `up` → migrate sequence. `BUILD=1` builds on
the box (bootstrap, `make deploy-prod`), `BUILD=0` pulls `APP_IMAGE` (CD,
`make deploy-image`).

Host keys move to an `SSH_KNOWN_HOSTS` secret — no runtime keyscan, no
`StrictHostKeyChecking=no`. A `v*` tag now publishes a versioned image and a
GitHub Release.

New secrets: `SSH_KNOWN_HOSTS`, `GHCR_USER`, `GHCR_PULL_TOKEN` (documented in
`docs/readme/contributing.md`).

Testing: `make lint`, `make test` (541 passed), `actionlint`, `shellcheck`, and
`deploy.sh` run end to end against a live stack in `BUILD=1` mode. The `BUILD=0`
pull path cannot be exercised until the first CI push lands an image in GHCR.


Release promotes rather than rebuilds: `docker buildx imagetools create` copies
the `sha-<12>` image CI built onto the `vX.Y.Z` tag by digest, so the released
artifact is the one CI tested. CD is gated on the `DEPLOY_ENABLED` repository
variable, so a fork does not fail a deploy against unset SSH secrets.
