### PR TITLE
refactor(errors): flat {code,message} contract, admission policies, account gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Every error, from the application and from nginx alike, has one flat shape:
   `"errors": [{"field": "...", "message": "..."}]`.
 - Rate-limit errors (429) additionally carry `"retry_after"` (seconds) in the
   body and the `Retry-After` header.
+- `token_expired` (401) from the refresh endpoint means the session is over —
+  send the user to login; retrying the refresh would loop.
 - Login answers a single `invalid_credentials` code for every failure reason —
   wrong password, unknown email, blocked or unverified account — by design.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,24 @@ Production-ready FastAPI template with modular architecture, async stack, and fu
 - Type safety: mypy in strict mode; strict settings (no implicit Optional, no untyped defs, disallow Any in generics) keep interfaces honest and catch regressions early.
 - Tooling: pre-commit/ruff/black/mypy, pytest (asyncio), Alembic migrations.
 
+### Error responses
+
+Every error, from the application and from nginx alike, has one flat shape:
+
+```json
+{"code": "invalid_credentials", "message": "Incorrect email or password."}
+```
+
+- `code` is a stable machine-readable key from `src/core/errors/codes.py`
+  (`ErrorCode`); build client-side translations on it, never on `message`.
+- `message` is an English fallback for developers.
+- Validation errors (422) additionally carry
+  `"errors": [{"field": "...", "message": "..."}]`.
+- Rate-limit errors (429) additionally carry `"retry_after"` (seconds) in the
+  body and the `Retry-After` header.
+- Login answers a single `invalid_credentials` code for every failure reason —
+  wrong password, unknown email, blocked or unverified account — by design.
+
 ## Email Links
 Verification and password-reset emails link to your front-end, never to the API, and
 never to a host taken from the request — a forged `Host` on `POST /password/reset`

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Production-ready FastAPI template with modular architecture, async stack, and fu
 - Type safety: mypy in strict mode; strict settings (no implicit Optional, no untyped defs, disallow Any in generics) keep interfaces honest and catch regressions early.
 - Tooling: pre-commit/ruff/black/mypy, pytest (asyncio), Alembic migrations.
 
-### Error responses
+## Error responses
 
 Every error, from the application and from nginx alike, has one flat shape:
 

--- a/docs/readme/security.md
+++ b/docs/readme/security.md
@@ -97,7 +97,7 @@ Three-tier model:
 - `Permission` enum — 28 granular permissions (view, create, edit, delete per resource).
 - `UserRole` enum — `ADMIN`, `EDITOR`, `VIEWER`.
 - `ROLE_PERMISSIONS` matrix — maps each role to its allowed permissions.
-- `require_permission()` — FastAPI dependency that checks active + verified + permitted.
+- `require_permission()` — FastAPI dependency that checks RBAC only; account admission (active + verified) is enforced by `get_current_user`.
 
 **Why it matters:** Endpoint-level auth checks (`Depends(current_user)`) only verify identity. Permission checks verify authorization, preventing horizontal and vertical privilege escalation.
 

--- a/docs/src/user/auth/REFRESH_TOKEN_IMPLEMENTATION.md
+++ b/docs/src/user/auth/REFRESH_TOKEN_IMPLEMENTATION.md
@@ -114,9 +114,12 @@ CSRF check fails → 403 (`AccessForbiddenException`).
 - Dependency returns `(user, payload)` to the use case.
 
 ## 3) Domain checks before rotation
-- `GetTokensByRefreshUserUseCase` receives the current user from dependency.
-  - If blocked → `PermissionDeniedException`.
-  - If not verified → `InstanceProcessingException`.
+- `GetTokensByRefreshUserUseCase` receives the current user from dependency and runs
+  `account_access_violation`/`ensure_can_use_session` (`src/user/policies.py`). Unlike
+  login, the caller already proved possession of a valid refresh token, so the real
+  reason is reported instead of being masked:
+  - If blocked → `UserBlockedError` (403, `user_blocked`).
+  - If not verified → `UserNotVerifiedError` (403, `user_not_verified`).
 
 ## 4) Rotation execution
 - `rotate_refresh_token`:

--- a/infra/nginx/proxy.inc
+++ b/infra/nginx/proxy.inc
@@ -4,7 +4,7 @@
 # included from inside a server block, not loaded on its own.
 
 # Errors nginx answers itself never reach the app, so its stock HTML pages would
-# break the {"error","message"} contract every other response follows: an
+# break the {"code","message"} contract every other response follows: an
 # oversized body (413) and an app that is down or too slow (502/504).
 error_page 413 = @error_payload_too_large;
 error_page 502 = @error_bad_gateway;
@@ -21,7 +21,7 @@ location @error_payload_too_large {
     add_header Access-Control-Allow-Origin $http_origin always;
     add_header Access-Control-Allow-Credentials true always;
     add_header Vary Origin always;
-    return 413 '{"error":"Payload too large","message":"Request body exceeds the maximum allowed size"}';
+    return 413 '{"code":"payload_too_large","message":"Request body exceeds the maximum allowed size"}';
 }
 
 location @error_bad_gateway {
@@ -29,7 +29,7 @@ location @error_bad_gateway {
     add_header Access-Control-Allow-Origin $http_origin always;
     add_header Access-Control-Allow-Credentials true always;
     add_header Vary Origin always;
-    return 502 '{"error":"Bad gateway","message":"The service is temporarily unreachable"}';
+    return 502 '{"code":"bad_gateway","message":"The service is temporarily unreachable"}';
 }
 
 location @error_gateway_timeout {
@@ -37,7 +37,7 @@ location @error_gateway_timeout {
     add_header Access-Control-Allow-Origin $http_origin always;
     add_header Access-Control-Allow-Credentials true always;
     add_header Vary Origin always;
-    return 504 '{"error":"Gateway timeout","message":"The service took too long to respond"}';
+    return 504 '{"code":"gateway_timeout","message":"The service took too long to respond"}';
 }
 
 location / {

--- a/src/core/errors/codes.py
+++ b/src/core/errors/codes.py
@@ -28,6 +28,7 @@ class ErrorCode(StrEnum):
     RATE_LIMITED = "rate_limited"
     INVALID_QUERY = "invalid_query"
     PROCESSING_ERROR = "processing_error"
+    METHOD_NOT_ALLOWED = "method_not_allowed"
     # Produced only by the nginx error pages, never by the application.
     BAD_GATEWAY = "bad_gateway"
     GATEWAY_TIMEOUT = "gateway_timeout"

--- a/src/core/errors/codes.py
+++ b/src/core/errors/codes.py
@@ -14,7 +14,7 @@ class ErrorCode(StrEnum):
     SERVICE_UNAVAILABLE = "service_unavailable"
     VALIDATION_ERROR = "validation_error"
     UNAUTHORIZED = "unauthorized"
-    TOKEN_EXPIRED = "token_expired"
+    TOKEN_EXPIRED = "token_expired"  # nosec B105
     FORBIDDEN = "forbidden"
     PERMISSION_DENIED = "permission_denied"
     CSRF_FAILED = "csrf_failed"

--- a/src/core/errors/codes.py
+++ b/src/core/errors/codes.py
@@ -1,0 +1,33 @@
+from enum import StrEnum
+
+
+class ErrorCode(StrEnum):
+    """Stable machine-readable error codes: the `code` field of every error body.
+
+    This enum is the complete client-facing registry, including the two codes
+    produced only by the nginx error pages (`infra/nginx/proxy.inc`). A frontend
+    keeps a `code -> translation` map; `message` is the English fallback.
+    """
+
+    INTERNAL_ERROR = "internal_error"
+    INFRASTRUCTURE_ERROR = "infrastructure_error"
+    SERVICE_UNAVAILABLE = "service_unavailable"
+    VALIDATION_ERROR = "validation_error"
+    UNAUTHORIZED = "unauthorized"
+    TOKEN_EXPIRED = "token_expired"
+    FORBIDDEN = "forbidden"
+    PERMISSION_DENIED = "permission_denied"
+    CSRF_FAILED = "csrf_failed"
+    USER_BLOCKED = "user_blocked"
+    USER_NOT_VERIFIED = "user_not_verified"
+    INVALID_CREDENTIALS = "invalid_credentials"
+    NOT_FOUND = "not_found"
+    ALREADY_EXISTS = "already_exists"
+    INVALID_REFERENCE = "invalid_reference"
+    PAYLOAD_TOO_LARGE = "payload_too_large"
+    RATE_LIMITED = "rate_limited"
+    INVALID_QUERY = "invalid_query"
+    PROCESSING_ERROR = "processing_error"
+    # Produced only by the nginx error pages, never by the application.
+    BAD_GATEWAY = "bad_gateway"
+    GATEWAY_TIMEOUT = "gateway_timeout"

--- a/src/core/errors/exceptions.py
+++ b/src/core/errors/exceptions.py
@@ -1,28 +1,62 @@
-from typing import Any
+from typing import Any, ClassVar
+
+from src.core.errors.codes import ErrorCode
 
 
 class CoreException(Exception):
+    """Base project exception.
+
+    Subclasses declare response behaviour as class attributes; a single generic
+    handler serializes any of them, so adding an error type means adding a
+    subclass, not a handler.
+    """
+
+    status_code: ClassVar[int] = 400
+    error_code: ClassVar[ErrorCode] = ErrorCode.PROCESSING_ERROR
+    log_level: ClassVar[str] = "info"
+    capture_to_sentry: ClassVar[bool] = False
+
     def __init__(
         self, message: str | None = None, additional_info: dict[str, Any] | None = None
     ):
         self.message = message
         self.additional_info = additional_info
 
+    def response_headers(self) -> dict[str, str]:
+        return {}
+
+    def body_extras(self) -> dict[str, Any]:
+        return {}
+
 
 class InfrastructureException(CoreException):
-    pass
+    status_code = 500
+    error_code = ErrorCode.INFRASTRUCTURE_ERROR
+    log_level = "error"
+    capture_to_sentry = True
 
 
 class ServiceUnavailableException(CoreException):
-    """A dependency the caller needs right now is unreachable (HTTP 503)."""
+    """A dependency the caller needs right now is unreachable (HTTP 503).
+
+    Deliberately never captured to Sentry: readiness probes poll every few
+    seconds, so a minute of downtime would file dozens of identical events for
+    a state the orchestrator already sees through the 503.
+    """
+
+    status_code = 503
+    error_code = ErrorCode.SERVICE_UNAVAILABLE
+    log_level = "error"
 
 
 class InstanceNotFoundException(CoreException):
-    pass
+    status_code = 404
+    error_code = ErrorCode.NOT_FOUND
 
 
 class InstanceAlreadyExistsException(CoreException):
-    pass
+    status_code = 409
+    error_code = ErrorCode.ALREADY_EXISTS
 
 
 class InstanceProcessingException(CoreException):
@@ -30,14 +64,20 @@ class InstanceProcessingException(CoreException):
 
 
 class PayloadTooLargeException(CoreException):
-    pass
+    status_code = 413
+    error_code = ErrorCode.PAYLOAD_TOO_LARGE
 
 
 class FilteringError(CoreException):
-    pass
+    error_code = ErrorCode.INVALID_QUERY
+    log_level = "warning"
 
 
 class UnauthorizedException(CoreException):
+    status_code = 401
+    error_code = ErrorCode.UNAUTHORIZED
+    log_level = "warning"
+
     def __init__(
         self,
         message: str | None = None,
@@ -49,20 +89,32 @@ class UnauthorizedException(CoreException):
         # Basic challenge that makes a browser show a login prompt for the docs.
         self.www_authenticate = www_authenticate
 
+    def response_headers(self) -> dict[str, str]:
+        if self.www_authenticate:
+            return {"WWW-Authenticate": self.www_authenticate}
+        return {}
+
 
 class AccessForbiddenException(CoreException):
-    pass
+    status_code = 403
+    error_code = ErrorCode.FORBIDDEN
+    log_level = "warning"
 
 
 class NotAcceptableException(CoreException):
-    pass
+    status_code = 406
 
 
 class PermissionDeniedException(CoreException):
-    pass
+    status_code = 403
+    error_code = ErrorCode.PERMISSION_DENIED
+    log_level = "warning"
 
 
 class TooManyRequestsException(CoreException):
+    status_code = 429
+    error_code = ErrorCode.RATE_LIMITED
+
     def __init__(
         self,
         message: str | None = None,
@@ -71,3 +123,13 @@ class TooManyRequestsException(CoreException):
     ):
         super().__init__(message, additional_info)
         self.retry_after = retry_after
+
+    def response_headers(self) -> dict[str, str]:
+        if self.retry_after:
+            return {"Retry-After": str(self.retry_after)}
+        return {}
+
+    def body_extras(self) -> dict[str, Any]:
+        if self.retry_after:
+            return {"retry_after": self.retry_after}
+        return {}

--- a/src/core/errors/exceptions.py
+++ b/src/core/errors/exceptions.py
@@ -96,12 +96,6 @@ class AccessForbiddenException(CoreException):
     log_level = "warning"
 
 
-class PermissionDeniedException(CoreException):
-    status_code = 403
-    error_code = ErrorCode.PERMISSION_DENIED
-    log_level = "warning"
-
-
 class TooManyRequestsException(CoreException):
     status_code = 429
     error_code = ErrorCode.RATE_LIMITED

--- a/src/core/errors/exceptions.py
+++ b/src/core/errors/exceptions.py
@@ -54,11 +54,6 @@ class InstanceNotFoundException(CoreException):
     error_code = ErrorCode.NOT_FOUND
 
 
-class InstanceAlreadyExistsException(CoreException):
-    status_code = 409
-    error_code = ErrorCode.ALREADY_EXISTS
-
-
 class InstanceProcessingException(CoreException):
     pass
 
@@ -99,10 +94,6 @@ class AccessForbiddenException(CoreException):
     status_code = 403
     error_code = ErrorCode.FORBIDDEN
     log_level = "warning"
-
-
-class NotAcceptableException(CoreException):
-    status_code = 406
 
 
 class PermissionDeniedException(CoreException):

--- a/src/core/errors/handlers.py
+++ b/src/core/errors/handlers.py
@@ -1,14 +1,14 @@
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from fastapi import Request
+from fastapi import Request, Response
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from fastapi.utils import is_body_allowed_for_status_code
 from pydantic import ValidationError
 import sentry_sdk
 from starlette.exceptions import HTTPException as StarletteHTTPException
-from starlette.responses import Response
 
 from loggers import get_logger
 from src.core.errors.codes import ErrorCode
@@ -118,7 +118,7 @@ async def handle_core_exception(request: Request, exc: CoreException) -> JSONRes
 async def handle_http_exception(
     request: Request,
     exc: StarletteHTTPException,
-) -> JSONResponse:
+) -> Response:
     """Translate framework-raised HTTPExceptions onto the error contract.
 
     FastAPI's security utilities and Starlette's router raise bare
@@ -126,6 +126,8 @@ async def handle_http_exception(
     wrong method -> 405); without this handler they would answer
     Starlette's default {"detail": ...} body and break the contract.
     """
+    if not is_body_allowed_for_status_code(exc.status_code):
+        return Response(status_code=exc.status_code, headers=exc.headers or None)
     code = _HTTP_STATUS_TO_ERROR_CODE.get(
         exc.status_code,
         (

--- a/src/core/errors/handlers.py
+++ b/src/core/errors/handlers.py
@@ -108,7 +108,12 @@ async def handle_core_exception(request: Request, exc: CoreException) -> JSONRes
 def _format_validation_errors(errors: list[dict[str, Any]]) -> list[dict[str, str]]:
     formatted = []
     for error in errors:
-        location = [str(part) for part in error.get("loc", ()) if part != "body"]
+        loc = tuple(error.get("loc", ()))
+        # Only FastAPI's leading "body" prefix is dropped; any other segment
+        # named "body" (e.g. a field literally called "body") is kept verbatim.
+        if loc and loc[0] == "body":
+            loc = loc[1:]
+        location = [str(part) for part in loc]
         formatted.append(
             {
                 "field": ".".join(location) or "body",

--- a/src/core/errors/handlers.py
+++ b/src/core/errors/handlers.py
@@ -10,21 +10,8 @@ import sentry_sdk
 from starlette.responses import Response
 
 from loggers import get_logger
-from src.core.errors.exceptions import (
-    AccessForbiddenException,
-    CoreException,
-    FilteringError,
-    InfrastructureException,
-    InstanceAlreadyExistsException,
-    InstanceNotFoundException,
-    InstanceProcessingException,
-    NotAcceptableException,
-    PayloadTooLargeException,
-    PermissionDeniedException,
-    ServiceUnavailableException,
-    TooManyRequestsException,
-    UnauthorizedException,
-)
+from src.core.errors.codes import ErrorCode
+from src.core.errors.exceptions import CoreException
 
 response_logger = get_logger("app.request.error_response", plain_format=True)
 
@@ -32,19 +19,10 @@ response_logger = get_logger("app.request.error_response", plain_format=True)
 HandlerCallable = Callable[[Request, Exception], Awaitable[Response]]
 
 
-def format_error_response(error_type: str, message: str | None) -> dict[str, Any]:
-    """
-    Format error response content for JSONResponse
-
-    Args:
-        error_type: Type of error (e.g., "Unauthorized", "Instance not found")
-        message: Detailed error message
-
-    Returns:
-        Dictionary with error information
-    """
+def format_error_response(code: ErrorCode, message: str | None) -> dict[str, Any]:
+    """Build the flat error body every response follows: {"code", "message"}."""
     return {
-        "error": error_type,
+        "code": code,
         "message": message or "No additional details available",
     }
 
@@ -112,219 +90,68 @@ def format_log_message(
     return log_msg
 
 
-async def handle_infrastructure_exception(
-    request: Request,
-    exc: InfrastructureException,
-) -> JSONResponse:
-    error_type = "Infrastructure error"
-    log_msg = format_log_message(request, error_type, exc.message, exc.additional_info)
-    response_logger.error(log_msg)
-    sentry_sdk.capture_exception(exc)
+async def handle_core_exception(request: Request, exc: CoreException) -> JSONResponse:
+    log_message = format_log_message(
+        request, exc.error_code, exc.message, exc.additional_info
+    )
+    getattr(response_logger, exc.log_level)(log_message)
+    if exc.capture_to_sentry:
+        sentry_sdk.capture_exception(exc)
+    headers = exc.response_headers()
     return JSONResponse(
-        status_code=500,
-        content=format_error_response(error_type, exc.message),
+        status_code=exc.status_code,
+        content=format_error_response(exc.error_code, exc.message) | exc.body_extras(),
+        headers=headers or None,
     )
 
 
-# Deliberately no Sentry capture: readiness probes poll every few seconds, so a
-# minute of downtime would file dozens of identical events for a state the
-# orchestrator already sees through the 503.
-async def handle_service_unavailable_exception(
-    request: Request,
-    exc: ServiceUnavailableException,
-) -> JSONResponse:
-    error_type = "Service unavailable"
-    log_msg = format_log_message(request, error_type, exc.message, exc.additional_info)
-    response_logger.error(log_msg)
-    return JSONResponse(
-        status_code=503,
-        content=format_error_response(error_type, exc.message),
-    )
+def _format_validation_errors(errors: list[dict[str, Any]]) -> list[dict[str, str]]:
+    formatted = []
+    for error in errors:
+        location = [str(part) for part in error.get("loc", ()) if part != "body"]
+        formatted.append(
+            {
+                "field": ".".join(location) or "body",
+                "message": str(error.get("msg", "Invalid value")),
+            }
+        )
+    return formatted
 
 
 async def handle_request_validation_exception(
     request: Request,
     exc: RequestValidationError,
 ) -> JSONResponse:
-    error_type = "Request validation error"
-    safe_detail = jsonable_encoder(exc.errors())
-    log_msg = format_log_message(
+    safe_errors = _format_validation_errors(jsonable_encoder(exc.errors()))
+    log_message = format_log_message(
         request,
-        error_type,
-        str(safe_detail),
+        ErrorCode.VALIDATION_ERROR,
+        str(safe_errors),
         include_request_path=True,
     )
-    response_logger.debug(log_msg)
-    return JSONResponse(status_code=422, content={"detail": safe_detail})
+    response_logger.debug(log_message)
+    return JSONResponse(
+        status_code=422,
+        content=format_error_response(
+            ErrorCode.VALIDATION_ERROR, "Request validation failed"
+        )
+        | {"errors": safe_errors},
+    )
 
 
 async def handle_validation_error(
     request: Request,
     exc: ValidationError,
 ) -> JSONResponse:
-    error_type = "Backend validation error"
-    safe_detail = jsonable_encoder(exc.errors())
-    log_msg = format_log_message(
+    log_message = format_log_message(
         request,
-        error_type,
-        str(safe_detail),
+        ErrorCode.INTERNAL_ERROR,
+        str(jsonable_encoder(exc.errors())),
         include_request_path=True,
     )
-    response_logger.error(log_msg)
+    response_logger.error(log_message)
     sentry_sdk.capture_exception(exc)
-    return JSONResponse(status_code=500, content={"detail": "Unexpected error"})
-
-
-async def handle_core_exception(
-    request: Request,
-    exc: CoreException,
-) -> JSONResponse:
-    error_type = "Bad request"
-    log_msg = format_log_message(request, error_type, exc.message, exc.additional_info)
-    response_logger.info(log_msg)
     return JSONResponse(
-        status_code=400,
-        content=format_error_response(error_type, exc.message),
-    )
-
-
-async def handle_instance_not_found_exception(
-    request: Request,
-    exc: InstanceNotFoundException,
-) -> JSONResponse:
-    error_type = "Instance not found"
-    log_msg = format_log_message(request, error_type, exc.message, exc.additional_info)
-    response_logger.info(log_msg)
-    return JSONResponse(
-        status_code=404,
-        content=format_error_response(error_type, exc.message),
-    )
-
-
-async def handle_instance_already_exists_exception(
-    request: Request,
-    exc: InstanceAlreadyExistsException,
-) -> JSONResponse:
-    error_type = "Instance already exists"
-    log_msg = format_log_message(request, error_type, exc.message, exc.additional_info)
-    response_logger.info(log_msg)
-    return JSONResponse(
-        status_code=409,
-        content=format_error_response(error_type, exc.message),
-    )
-
-
-async def handle_instance_processing_exception(
-    request: Request,
-    exc: InstanceProcessingException,
-) -> JSONResponse:
-    error_type = "Instance processing error"
-    log_msg = format_log_message(request, error_type, exc.message, exc.additional_info)
-    response_logger.info(log_msg)
-    return JSONResponse(
-        status_code=400,
-        content=format_error_response(error_type, exc.message),
-    )
-
-
-async def handle_payload_too_large_exception(
-    request: Request,
-    exc: PayloadTooLargeException,
-) -> JSONResponse:
-    error_type = "Payload too large"
-    log_msg = format_log_message(request, error_type, exc.message, exc.additional_info)
-    response_logger.info(log_msg)
-    return JSONResponse(
-        status_code=413,
-        content=format_error_response(error_type, exc.message),
-    )
-
-
-async def handle_filtering_error(
-    request: Request,
-    exc: FilteringError,
-) -> JSONResponse:
-    error_type = "Filtering error"
-    log_msg = format_log_message(request, error_type, exc.message, exc.additional_info)
-    response_logger.warning(log_msg)
-    return JSONResponse(
-        status_code=400,
-        content=format_error_response(error_type, exc.message),
-    )
-
-
-async def handle_unauthorized_exception(
-    request: Request,
-    exc: UnauthorizedException,
-) -> JSONResponse:
-    error_type = "Unauthorized"
-    log_msg = format_log_message(request, error_type, exc.message, exc.additional_info)
-    response_logger.warning(log_msg)
-
-    headers = {}
-    if exc.www_authenticate:
-        headers["WWW-Authenticate"] = exc.www_authenticate
-
-    return JSONResponse(
-        status_code=401,
-        content=format_error_response(error_type, exc.message),
-        headers=headers,
-    )
-
-
-async def handle_access_forbidden_exception(
-    request: Request,
-    exc: AccessForbiddenException,
-) -> JSONResponse:
-    error_type = "Forbidden"
-    log_msg = format_log_message(request, error_type, exc.message, exc.additional_info)
-    response_logger.warning(log_msg)
-    return JSONResponse(
-        status_code=403,
-        content=format_error_response(error_type, exc.message),
-    )
-
-
-async def handle_not_acceptable_exception(
-    request: Request,
-    exc: NotAcceptableException,
-) -> JSONResponse:
-    error_type = "Not Acceptable"
-    log_msg = format_log_message(request, error_type, exc.message, exc.additional_info)
-    response_logger.info(log_msg)
-    return JSONResponse(
-        status_code=406,
-        content=format_error_response(error_type, exc.message),
-    )
-
-
-async def handle_permission_denied_exception(
-    request: Request,
-    exc: PermissionDeniedException,
-) -> JSONResponse:
-    error_type = "Permission Denied"
-    log_msg = format_log_message(request, error_type, exc.message, exc.additional_info)
-    response_logger.warning(log_msg)
-    return JSONResponse(
-        status_code=403,
-        content=format_error_response(error_type, exc.message),
-    )
-
-
-async def handle_too_many_requests_exception(
-    request: Request,
-    exc: TooManyRequestsException,
-) -> JSONResponse:
-    error_type = "Too Many Requests"
-    log_msg = format_log_message(request, error_type, exc.message)
-    response_logger.info(log_msg)
-
-    headers = {}
-    if exc.retry_after:
-        headers["Retry-After"] = str(exc.retry_after)
-
-    return JSONResponse(
-        status_code=429,
-        content=format_error_response(error_type, exc.message),
-        headers=headers,
+        status_code=500,
+        content=format_error_response(ErrorCode.INTERNAL_ERROR, "Unexpected error"),
     )

--- a/src/core/errors/handlers.py
+++ b/src/core/errors/handlers.py
@@ -7,6 +7,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 import sentry_sdk
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import Response
 
 from loggers import get_logger
@@ -17,6 +18,15 @@ response_logger = get_logger("app.request.error_response", plain_format=True)
 
 # Type for exception handler
 HandlerCallable = Callable[[Request, Exception], Awaitable[Response]]
+
+_HTTP_STATUS_TO_ERROR_CODE = {
+    401: ErrorCode.UNAUTHORIZED,
+    403: ErrorCode.FORBIDDEN,
+    404: ErrorCode.NOT_FOUND,
+    405: ErrorCode.METHOD_NOT_ALLOWED,
+    413: ErrorCode.PAYLOAD_TOO_LARGE,
+    429: ErrorCode.RATE_LIMITED,
+}
 
 
 def format_error_response(code: ErrorCode, message: str | None) -> dict[str, Any]:
@@ -102,6 +112,38 @@ async def handle_core_exception(request: Request, exc: CoreException) -> JSONRes
         status_code=exc.status_code,
         content=format_error_response(exc.error_code, exc.message) | exc.body_extras(),
         headers=headers or None,
+    )
+
+
+async def handle_http_exception(
+    request: Request,
+    exc: StarletteHTTPException,
+) -> JSONResponse:
+    """Translate framework-raised HTTPExceptions onto the error contract.
+
+    FastAPI's security utilities and Starlette's router raise bare
+    HTTPExceptions (missing credentials -> 401, unmatched path -> 404,
+    wrong method -> 405); without this handler they would answer
+    Starlette's default {"detail": ...} body and break the contract.
+    """
+    code = _HTTP_STATUS_TO_ERROR_CODE.get(
+        exc.status_code,
+        (
+            ErrorCode.INTERNAL_ERROR
+            if exc.status_code >= 500
+            else ErrorCode.PROCESSING_ERROR
+        ),
+    )
+    message = exc.detail if isinstance(exc.detail, str) else None
+    log_message = format_log_message(request, code, message, include_request_path=True)
+    if exc.status_code >= 500:
+        response_logger.error(log_message)
+    else:
+        response_logger.debug(log_message)
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=format_error_response(code, message),
+        headers=exc.headers or None,
     )
 
 

--- a/src/core/middleware.py
+++ b/src/core/middleware.py
@@ -15,6 +15,8 @@ from sqlalchemy.exc import (
 from starlette.responses import Response
 
 from loggers import get_logger
+from src.core.errors.codes import ErrorCode
+from src.core.errors.handlers import format_error_response
 
 logger = get_logger(__name__)
 timing_logger = get_logger("src.request.timing", plain_format=True)
@@ -56,6 +58,15 @@ class PostgresqlErrorHandlingResult:
     response: JSONResponse
     send_to_sentry: bool
     is_server_error: bool
+
+
+def _internal_error_response() -> JSONResponse:
+    return JSONResponse(
+        status_code=500,
+        content=format_error_response(
+            ErrorCode.INTERNAL_ERROR, UNEXPECTED_ERROR_DETAIL
+        ),
+    )
 
 
 def register_middlewares(app: FastAPI) -> None:
@@ -123,18 +134,17 @@ def register_middlewares(app: FastAPI) -> None:
             )
             sentry_sdk.capture_exception(e)
             return JSONResponse(
-                status_code=500,
-                content={
-                    "detail": "Database connection error. Please try again later."
-                },
+                status_code=503,
+                content=format_error_response(
+                    ErrorCode.SERVICE_UNAVAILABLE,
+                    "Database is temporarily unavailable. Please try again later.",
+                ),
             )
 
         except ProgrammingError as e:
             logger.error(f"SQL syntax error at {request.url.path}: {str(e.orig)}")
             sentry_sdk.capture_exception(e)
-            return JSONResponse(
-                status_code=500, content={"detail": "Database query error."}
-            )
+            return _internal_error_response()
 
     @app.middleware("http")
     async def unexpected_error_middleware(
@@ -151,9 +161,7 @@ def register_middlewares(app: FastAPI) -> None:
                 error_traceback,
             )
             sentry_sdk.capture_exception(e)
-            return JSONResponse(
-                status_code=500, content={"detail": UNEXPECTED_ERROR_DETAIL}
-            )
+            return _internal_error_response()
 
 
 def handle_postgresql_error(
@@ -162,11 +170,13 @@ def handle_postgresql_error(
     """
     Build a structured handling result for PostgreSQL IntegrityError with HTTP response, Sentry flag, and log severity.
 
-    A unique violation answers 409 with the conflicting value, which on
-    registration tells a caller that an address is already taken. That is a
-    deliberate trade: account enumeration through this route is cheap anyway
-    (login timing, password reset), while a client that cannot distinguish
-    "already registered" from a generic failure sends the user in circles.
+    A unique violation answers 409, which on registration tells a caller that
+    an address is already taken. That is a deliberate trade: account
+    enumeration through this route is cheap anyway (login timing, password
+    reset), while a client that cannot distinguish "already registered" from
+    a generic failure sends the user in circles. The conflicting value itself
+    is never echoed back — the DB DETAIL can carry someone else's data (an
+    email, a phone number), so only the status and code are client-facing.
     """
     orig_error = error.orig
     sqlstate = getattr(orig_error, "sqlstate", None)
@@ -181,13 +191,13 @@ def handle_postgresql_error(
             detail_message = "No additional details provided."
 
     if sqlstate == "23505":  # UniqueViolation
-        match = re.search(r"\(([^)]+)\)", detail_message)
-        if match:
-            first_value = match.group(1)
-        else:
-            first_value = detail_message
         return PostgresqlErrorHandlingResult(
-            response=JSONResponse(status_code=409, content={"detail": first_value}),
+            response=JSONResponse(
+                status_code=409,
+                content=format_error_response(
+                    ErrorCode.ALREADY_EXISTS, "Resource already exists."
+                ),
+            ),
             send_to_sentry=False,
             is_server_error=False,
         )
@@ -203,39 +213,37 @@ def handle_postgresql_error(
             detail_message,
         )
         return PostgresqlErrorHandlingResult(
-            response=JSONResponse(
-                status_code=500, content={"detail": UNEXPECTED_ERROR_DETAIL}
-            ),
+            response=_internal_error_response(),
             send_to_sentry=True,
             is_server_error=True,
         )
     if sqlstate == "23503":  # ForeignKeyViolation
         return PostgresqlErrorHandlingResult(
-            response=JSONResponse(status_code=400, content={"detail": detail_message}),
+            response=JSONResponse(
+                status_code=400,
+                content=format_error_response(
+                    ErrorCode.INVALID_REFERENCE,
+                    "Referenced resource does not exist.",
+                ),
+            ),
             send_to_sentry=False,
             is_server_error=False,
         )
     if sqlstate == "23514":  # CheckViolation
         return PostgresqlErrorHandlingResult(
-            response=JSONResponse(
-                status_code=500, content={"detail": UNEXPECTED_ERROR_DETAIL}
-            ),
+            response=_internal_error_response(),
             send_to_sentry=True,
             is_server_error=True,
         )
     if sqlstate == "23P01":  # ExclusionViolation
         return PostgresqlErrorHandlingResult(
-            response=JSONResponse(
-                status_code=500, content={"detail": UNEXPECTED_ERROR_DETAIL}
-            ),
+            response=_internal_error_response(),
             send_to_sentry=True,
             is_server_error=True,
         )
 
     return PostgresqlErrorHandlingResult(
-        response=JSONResponse(
-            status_code=500, content={"detail": UNEXPECTED_ERROR_DETAIL}
-        ),
+        response=_internal_error_response(),
         send_to_sentry=True,
         is_server_error=True,
     )

--- a/src/main/presentation.py
+++ b/src/main/presentation.py
@@ -3,11 +3,13 @@ from typing import cast
 from fastapi import APIRouter, FastAPI
 from fastapi.exceptions import RequestValidationError
 from pydantic import ValidationError
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from src.core.errors.exceptions import CoreException
 from src.core.errors.handlers import (
     HandlerCallable,
     handle_core_exception,
+    handle_http_exception,
     handle_request_validation_exception,
     handle_validation_error,
 )
@@ -25,6 +27,10 @@ EXCEPTION_HANDLERS: tuple[tuple[type[Exception], HandlerCallable], ...] = (
         cast(HandlerCallable, handle_request_validation_exception),
     ),
     (ValidationError, cast(HandlerCallable, handle_validation_error)),
+    # FastAPI's HTTPException subclasses Starlette's, so this one registration
+    # covers framework-raised exceptions from both (missing credentials,
+    # unmatched routes, wrong methods) that would otherwise bypass the contract.
+    (StarletteHTTPException, cast(HandlerCallable, handle_http_exception)),
 )
 
 

--- a/src/main/presentation.py
+++ b/src/main/presentation.py
@@ -4,37 +4,11 @@ from fastapi import APIRouter, FastAPI
 from fastapi.exceptions import RequestValidationError
 from pydantic import ValidationError
 
-from src.core.errors.exceptions import (
-    AccessForbiddenException,
-    CoreException,
-    FilteringError,
-    InfrastructureException,
-    InstanceAlreadyExistsException,
-    InstanceNotFoundException,
-    InstanceProcessingException,
-    NotAcceptableException,
-    PayloadTooLargeException,
-    PermissionDeniedException,
-    ServiceUnavailableException,
-    TooManyRequestsException,
-    UnauthorizedException,
-)
+from src.core.errors.exceptions import CoreException
 from src.core.errors.handlers import (
     HandlerCallable,
-    handle_access_forbidden_exception,
     handle_core_exception,
-    handle_filtering_error,
-    handle_infrastructure_exception,
-    handle_instance_already_exists_exception,
-    handle_instance_not_found_exception,
-    handle_instance_processing_exception,
-    handle_not_acceptable_exception,
-    handle_payload_too_large_exception,
-    handle_permission_denied_exception,
     handle_request_validation_exception,
-    handle_service_unavailable_exception,
-    handle_too_many_requests_exception,
-    handle_unauthorized_exception,
     handle_validation_error,
 )
 from src.system import routers as system_routers
@@ -43,66 +17,14 @@ from src.system import routers as system_routers
 from src.user import routers as user_routers
 
 EXCEPTION_HANDLERS: tuple[tuple[type[Exception], HandlerCallable], ...] = (
-    (
-        InfrastructureException,
-        cast(HandlerCallable, handle_infrastructure_exception),
-    ),
-    (
-        ServiceUnavailableException,
-        cast(HandlerCallable, handle_service_unavailable_exception),
-    ),
+    # Starlette resolves handlers over the exception's MRO, so this one entry
+    # covers every CoreException subclass, current and future.
+    (CoreException, cast(HandlerCallable, handle_core_exception)),
     (
         RequestValidationError,
         cast(HandlerCallable, handle_request_validation_exception),
     ),
-    (
-        ValidationError,
-        cast(HandlerCallable, handle_validation_error),
-    ),
-    (
-        InstanceNotFoundException,
-        cast(HandlerCallable, handle_instance_not_found_exception),
-    ),
-    (
-        InstanceAlreadyExistsException,
-        cast(HandlerCallable, handle_instance_already_exists_exception),
-    ),
-    (
-        InstanceProcessingException,
-        cast(HandlerCallable, handle_instance_processing_exception),
-    ),
-    (
-        PayloadTooLargeException,
-        cast(HandlerCallable, handle_payload_too_large_exception),
-    ),
-    (
-        FilteringError,
-        cast(HandlerCallable, handle_filtering_error),
-    ),
-    (
-        CoreException,
-        cast(HandlerCallable, handle_core_exception),
-    ),
-    (
-        AccessForbiddenException,
-        cast(HandlerCallable, handle_access_forbidden_exception),
-    ),
-    (
-        UnauthorizedException,
-        cast(HandlerCallable, handle_unauthorized_exception),
-    ),
-    (
-        NotAcceptableException,
-        cast(HandlerCallable, handle_not_acceptable_exception),
-    ),
-    (
-        PermissionDeniedException,
-        cast(HandlerCallable, handle_permission_denied_exception),
-    ),
-    (
-        TooManyRequestsException,
-        cast(HandlerCallable, handle_too_many_requests_exception),
-    ),
+    (ValidationError, cast(HandlerCallable, handle_validation_error)),
 )
 
 

--- a/src/user/auth/cookies.py
+++ b/src/user/auth/cookies.py
@@ -3,10 +3,11 @@ from typing import Annotated, Final
 from fastapi import Depends, Response
 
 from loggers import get_logger
-from src.core.errors.exceptions import AccessForbiddenException, InfrastructureException
+from src.core.errors.exceptions import InfrastructureException
 from src.core.schemas import TokenModel
 from src.main.config import Config, CookieConfig, get_settings
 from src.user.auth.csrf import build_csrf_token, verify_csrf_token
+from src.user.auth.errors import CsrfFailedError
 from src.user.auth.token_transport import TokenTransport
 
 logger = get_logger(__name__)
@@ -129,7 +130,7 @@ class TokenCookieResponder:
         else:
             logger.warning("[CSRF] Refresh request carried a mismatched CSRF token.")
 
-        raise AccessForbiddenException(CSRF_FAILURE_MESSAGE)
+        raise CsrfFailedError(CSRF_FAILURE_MESSAGE)
 
     def _set_cookie(
         self,

--- a/src/user/auth/dependencies.py
+++ b/src/user/auth/dependencies.py
@@ -17,6 +17,7 @@ from src.user.auth.cookies import (
     TokenCookieResponder,
     get_token_cookie_responder,
 )
+from src.user.auth.errors import TokenExpiredError
 from src.user.auth.jwt_payload_schema import JWTPayload
 from src.user.auth.redis_keys import auth_redis_keys
 from src.user.auth.token_helpers import invalidate_all_user_sessions
@@ -336,7 +337,8 @@ async def verify_jti(token: str, redis_client: Redis) -> JWTPayload:
         JWTPayload: The verified JWT payload.
 
     Raises:
-        UnauthorizedException: If the token is expired, malformed, has an invalid
+        TokenExpiredError: If the token has expired.
+        UnauthorizedException: If the token is malformed, has an invalid
             structure, was reused, or no longer matches the active Redis entry.
     """
     if isinstance(token, str) and token.lower().startswith("bearer "):
@@ -350,7 +352,7 @@ async def verify_jti(token: str, redis_client: Redis) -> JWTPayload:
         )
         payload_typed = cast(JWTPayload, payload)
     except jwt.ExpiredSignatureError:
-        raise UnauthorizedException("Token expired")
+        raise TokenExpiredError("Token expired")
     except jwt.PyJWTError:
         raise UnauthorizedException("Invalid token")
 

--- a/src/user/auth/dependencies.py
+++ b/src/user/auth/dependencies.py
@@ -23,6 +23,7 @@ from src.user.auth.redis_keys import auth_redis_keys
 from src.user.auth.token_helpers import invalidate_all_user_sessions
 from src.user.dependencies import get_user_repository
 from src.user.models import User
+from src.user.policies import ensure_can_use_session
 from src.user.repositories import UserRepository
 
 access_token_header = APIKeyHeader(name="Authorization", scheme_name="access-token")
@@ -114,45 +115,14 @@ async def verify_csrf(
     responder.verify_csrf(credentials.token, request.headers.get(CSRF_HEADER_NAME))
 
 
-async def get_current_user(
-    token: Annotated[str, Security(access_token_header)],
-    session: Annotated[AsyncSession, Depends(get_session)],
-    redis_client: Annotated[Redis, Depends(get_redis_client)],
-    user_repository: Annotated[UserRepository, Depends(get_user_repository)],
-) -> User:
-    """
-    Resolve the authenticated user from a valid access token.
-
-    Args:
-        token: The JWT access token from the Authorization header.
-        session: Database session.
-        redis_client: Redis client used to validate the active token JTI.
-        user_repository: Repository used to load the user entity.
-
-    Returns:
-        User: The authenticated user.
-
-    Raises:
-        UnauthorizedException: If the token is invalid, is not an access token,
-            or the user cannot be loaded.
-    """
-    authenticated = await get_current_user_with_session(
-        token=token,
-        session=session,
-        redis_client=redis_client,
-        user_repository=user_repository,
-    )
-    return authenticated.user
-
-
-async def get_current_user_with_session(
+async def authenticate_access_token(
     token: Annotated[str, Security(access_token_header)],
     session: Annotated[AsyncSession, Depends(get_session)],
     redis_client: Annotated[Redis, Depends(get_redis_client)],
     user_repository: Annotated[UserRepository, Depends(get_user_repository)],
 ) -> AuthenticatedUser:
     """
-    Resolve the authenticated user and current access-token session identifier.
+    Resolve the token to a user and session, WITHOUT the admission gate.
 
     Args:
         token: The JWT access token from the Authorization header.
@@ -187,6 +157,38 @@ async def get_current_user_with_session(
         raise credentials_exception
 
     return AuthenticatedUser(user=user, session_id=session_id)
+
+
+async def get_current_user_with_session(
+    authenticated: Annotated[AuthenticatedUser, Depends(authenticate_access_token)],
+) -> AuthenticatedUser:
+    """Authenticated AND admitted (active, verified) user with the session id."""
+    ensure_can_use_session(authenticated.user)
+    return authenticated
+
+
+async def get_current_user(
+    authenticated: Annotated[AuthenticatedUser, Depends(authenticate_access_token)],
+) -> User:
+    """The default auth dependency: authenticated AND admitted (active, verified).
+
+    Blocked or unverified accounts answer 403 with an honest code here; the
+    single opt-out is get_authenticated_user.
+    """
+    ensure_can_use_session(authenticated.user)
+    return authenticated.user
+
+
+async def get_authenticated_user(
+    authenticated: Annotated[AuthenticatedUser, Depends(authenticate_access_token)],
+) -> User:
+    """Authentication without the admission gate.
+
+    The single legitimate use is GET /me: a blocked or unverified account must
+    still read its own state (is_verified) so the client can show the right
+    screen. Any other use requires an explicit justification comment.
+    """
+    return authenticated.user
 
 
 async def get_logout_identity(

--- a/src/user/auth/errors.py
+++ b/src/user/auth/errors.py
@@ -1,0 +1,36 @@
+from src.core.errors.codes import ErrorCode
+from src.core.errors.exceptions import (
+    AccessForbiddenException,
+    InstanceProcessingException,
+    UnauthorizedException,
+)
+
+
+class UserBlockedError(AccessForbiddenException):
+    error_code = ErrorCode.USER_BLOCKED
+
+
+class UserNotVerifiedError(AccessForbiddenException):
+    error_code = ErrorCode.USER_NOT_VERIFIED
+
+
+class PermissionDeniedError(AccessForbiddenException):
+    error_code = ErrorCode.PERMISSION_DENIED
+
+
+class CsrfFailedError(AccessForbiddenException):
+    error_code = ErrorCode.CSRF_FAILED
+
+
+class TokenExpiredError(UnauthorizedException):
+    error_code = ErrorCode.TOKEN_EXPIRED
+
+
+class InvalidCredentialsError(InstanceProcessingException):
+    """Login failures answer HTTP 400 rather than 401 on purpose: SPA
+    interceptors commonly treat 401 as "refresh the token and retry", which
+    would loop on a login form. The 400 + `invalid_credentials` pair is
+    unambiguous for a client."""
+
+    error_code = ErrorCode.INVALID_CREDENTIALS
+    log_level = "debug"

--- a/src/user/auth/permissions/checker.py
+++ b/src/user/auth/permissions/checker.py
@@ -3,11 +3,8 @@ from typing import Annotated
 
 from fastapi import Depends
 
-from src.core.errors.exceptions import (
-    AccessForbiddenException,
-    PermissionDeniedException,
-)
 from src.user.auth.dependencies import get_current_user
+from src.user.auth.errors import PermissionDeniedError
 from src.user.auth.permissions.enum import Permission
 from src.user.auth.permissions.role_matrix import ROLE_PERMISSIONS
 from src.user.models import User
@@ -16,23 +13,14 @@ from src.user.models import User
 def require_permission(
     required_permission: Permission,
 ) -> Callable[[Annotated[User, Depends(get_current_user)]], User]:
+    # Account admission (active + verified) is enforced by get_current_user;
+    # this checker only decides RBAC.
     def checker(
         current_user: Annotated[User, Depends(get_current_user)],
     ) -> User:
-        if not current_user.is_active:
-            raise AccessForbiddenException(
-                "You do not have permission to access this resource. User is blocked",
-            )
-
-        if not current_user.is_verified:
-            raise AccessForbiddenException(
-                "You do not have permission to access this resource. Verified users only",
-            )
-
         permissions = ROLE_PERMISSIONS.get(current_user.role, set())
         if required_permission not in permissions:
-            raise PermissionDeniedException("Permission denied")
-
+            raise PermissionDeniedError("Permission denied")
         return current_user
 
     return checker

--- a/src/user/auth/usecases/get_access_by_refresh.py
+++ b/src/user/auth/usecases/get_access_by_refresh.py
@@ -5,10 +5,6 @@ import jwt
 from redis.asyncio import Redis
 
 from loggers import get_logger
-from src.core.errors.exceptions import (
-    InstanceProcessingException,
-    PermissionDeniedException,
-)
 from src.core.redis.dependencies import get_redis_client
 from src.core.schemas import TokenModel
 from src.core.utils.security import mask_email
@@ -16,6 +12,7 @@ from src.main.config import config
 from src.user.auth.jwt_payload_schema import JWTPayload
 from src.user.auth.security import create_access_token, rotate_refresh_token
 from src.user.models import User
+from src.user.policies import account_access_violation, ensure_can_use_session
 
 logger = get_logger(__name__)
 
@@ -34,7 +31,9 @@ class GetTokensByRefreshUserUseCase:
     - Refresh token must be valid and not reused (handled by rotate_refresh_token).
 
     Workflow:
-    1) Check if the user is active and verified.
+    1) Check account admission (active and verified) via policies.py; unlike
+       login, the real reason is reported since the caller already proved
+       possession of a valid refresh token.
     2) Rotate the refresh token (handles session invalidation and reuse detection).
     3) Decode the new refresh token to get the session ID.
     4) Create a new access token associated with the session.
@@ -44,8 +43,8 @@ class GetTokensByRefreshUserUseCase:
     - May invalidate sessions if token reuse is detected.
 
     Errors:
-    - PermissionDeniedException: if user is blocked.
-    - InstanceProcessingException: if user is not verified.
+    - UserBlockedError: if user is blocked.
+    - UserNotVerifiedError: if user is not verified.
     - UnauthorizedException: if token rotation fails.
 
     Returns:
@@ -60,19 +59,14 @@ class GetTokensByRefreshUserUseCase:
         user: User,
         old_token_payload: JWTPayload,
     ) -> TokenModel:
-        if not user.is_active:
+        violation = account_access_violation(user)
+        if violation is not None:
             logger.info(
-                "[RefreshTokens] Blocked user '%s' attempted refresh",
+                "[RefreshTokens] User '%s' fails admission (%s)",
                 mask_email(user.email),
+                violation,
             )
-            raise PermissionDeniedException("User is blocked")
-
-        if not user.is_verified:
-            logger.info(
-                "[RefreshTokens] Unverified user '%s' attempted refresh",
-                mask_email(user.email),
-            )
-            raise InstanceProcessingException("User is not verified")
+        ensure_can_use_session(user)
 
         # Use rotation helper to handle the previous token safely
         new_refresh_token = await rotate_refresh_token(

--- a/src/user/auth/usecases/login.py
+++ b/src/user/auth/usecases/login.py
@@ -9,7 +9,6 @@ from src.core.cache.dependencies import get_cache
 from src.core.cache.interface import Cache
 from src.core.database.session import get_unit_of_work
 from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
-from src.core.errors.exceptions import InstanceProcessingException
 from src.core.redis.dependencies import get_redis_client
 from src.core.schemas import TokenModel
 from src.core.utils.security import (
@@ -18,12 +17,17 @@ from src.core.utils.security import (
     needs_password_rehash,
     verify_password,
 )
+from src.user.auth.errors import InvalidCredentialsError
 from src.user.auth.schemas import LoginUserModel
 from src.user.auth.security import create_access_token, create_refresh_token
 from src.user.cache_keys import user_cache_keys
 from src.user.models import User
+from src.user.policies import (
+    INVALID_CREDENTIALS_MESSAGE,
+    account_access_violation,
+    ensure_can_authenticate,
+)
 
-INVALID_CREDENTIALS_MESSAGE = "Incorrect email or password."
 INVALID_CREDENTIALS_PASSWORD_HASH = hash_password("dummy-password")
 logger = get_logger(__name__)
 
@@ -38,17 +42,16 @@ class LoginUserUseCase:
     Validations:
     - User must exist.
     - Password must be correct.
-    - User must be verified.
-    - User must be active (not blocked).
+    - Account must pass admission (verified and active) - see policies.py.
 
     Workflow:
     1) Retrieve user by email.
     2) Verify password (using dummy hash if user not found to prevent timing attacks).
-    3) Check if user is verified.
-    4) Check if user is active.
-    5) Rehash and persist the password if needed.
-    6) Invalidate the user cache namespace.
-    7) Commit the transaction and generate access and refresh tokens.
+    3) Check account admission; a violation is masked into the same error as
+       bad credentials (anti-enumeration).
+    4) Rehash and persist the password if needed.
+    5) Invalidate the user cache namespace.
+    6) Commit the transaction and generate access and refresh tokens.
 
     Side effects:
     - Persists password hash updates when rehashing is required.
@@ -59,8 +62,8 @@ class LoginUserUseCase:
     - Token creation handles its own caching.
 
     Errors:
-    - InstanceProcessingException: if credentials are invalid, the user is not
-      verified, or the user is blocked.
+    - InvalidCredentialsError: wrong credentials, unverified or blocked account -
+      one code by design (anti-enumeration).
 
     Returns:
     - TokenModel with access and refresh tokens.
@@ -88,7 +91,7 @@ class LoginUserUseCase:
                     mask_email(data.email),
                 )
                 await verify_password(data.password, INVALID_CREDENTIALS_PASSWORD_HASH)
-                raise InstanceProcessingException(INVALID_CREDENTIALS_MESSAGE)
+                raise InvalidCredentialsError(INVALID_CREDENTIALS_MESSAGE)
 
             correct_password = await verify_password(data.password, user.password_hash)
             if not correct_password:
@@ -96,21 +99,16 @@ class LoginUserUseCase:
                     "[LoginUser] Incorrect password for user '%s'",
                     mask_email(data.email),
                 )
-                raise InstanceProcessingException(INVALID_CREDENTIALS_MESSAGE)
+                raise InvalidCredentialsError(INVALID_CREDENTIALS_MESSAGE)
 
-            if not user.is_verified:
+            violation = account_access_violation(user)
+            if violation is not None:
                 logger.debug(
-                    "[LoginUser] User with email '%s' not verified.",
+                    "[LoginUser] Account of '%s' fails admission (%s).",
                     mask_email(data.email),
+                    violation,
                 )
-                raise InstanceProcessingException(INVALID_CREDENTIALS_MESSAGE)
-
-            if not user.is_active:
-                logger.debug(
-                    "[LoginUser] User with email '%s' is blocked.",
-                    mask_email(data.email),
-                )
-                raise InstanceProcessingException(INVALID_CREDENTIALS_MESSAGE)
+            ensure_can_authenticate(user)
 
             await self._rehash_password_if_needed(uow, user, data.password)
             session_id = str(uuid4())

--- a/src/user/auth/usecases/register.py
+++ b/src/user/auth/usecases/register.py
@@ -38,7 +38,8 @@ class RegisterUseCase:
       after commit.
 
     Errors:
-    - InstanceAlreadyExistsException: if email or username already exists.
+    - Duplicate email/username surfaces as IntegrityError and is answered 409
+      with code "already_exists" by the database error middleware.
 
     Returns:
     - UserProfileViewModel: the newly created user profile.

--- a/src/user/auth/usecases/resend_verification.py
+++ b/src/user/auth/usecases/resend_verification.py
@@ -13,6 +13,7 @@ from src.user.auth.services.verification_notifier import (
     VerificationNotifier,
     get_verification_notifier,
 )
+from src.user.policies import verification_pending
 
 logger = get_logger(__name__)
 
@@ -62,7 +63,7 @@ class SendVerificationUseCase:
                     mask_email(data.email),
                 )
                 return SuccessResponse(success=True)
-            if user.is_verified:
+            if not verification_pending(user):
                 logger.debug(
                     "[ResendVerification] User with email '%s' already verified.",
                     mask_email(data.email),

--- a/src/user/auth/usecases/verify_email.py
+++ b/src/user/auth/usecases/verify_email.py
@@ -19,6 +19,7 @@ from src.user.auth.token_helpers import (
     validate_active_one_time_token,
 )
 from src.user.cache_keys import user_cache_keys
+from src.user.policies import verification_pending
 
 logger = get_logger(__name__)
 
@@ -92,7 +93,7 @@ class VerifyEmailUseCase:
                         mask_email(normalized_email),
                     )
                     return SuccessResponse(success=False)
-                if user.is_verified:
+                if not verification_pending(user):
                     await invalidate_active_one_time_token(
                         purpose="verification",
                         email=normalized_email,

--- a/src/user/policies.py
+++ b/src/user/policies.py
@@ -1,0 +1,65 @@
+from enum import StrEnum
+from typing import Protocol
+
+from src.user.auth.errors import (
+    InvalidCredentialsError,
+    UserBlockedError,
+    UserNotVerifiedError,
+)
+
+INVALID_CREDENTIALS_MESSAGE = "Incorrect email or password."
+
+
+class AccountLike(Protocol):
+    """The two flags the admission rule reads.
+
+    A Protocol instead of the ORM model keeps this module import-free of
+    sqlalchemy, so the rule is unit-testable with a plain object.
+    """
+
+    is_active: bool
+    is_verified: bool
+
+
+class AccountAccessViolation(StrEnum):
+    BLOCKED = "blocked"
+    NOT_VERIFIED = "not_verified"
+
+
+def account_access_violation(user: AccountLike) -> AccountAccessViolation | None:
+    """Single home of the "may this account be used" rule.
+
+    Blocked wins over unverified: a blocked account must stay unusable even
+    after it verifies its email.
+    """
+    if not user.is_active:
+        return AccountAccessViolation.BLOCKED
+    if not user.is_verified:
+        return AccountAccessViolation.NOT_VERIFIED
+    return None
+
+
+def ensure_can_authenticate(user: AccountLike) -> None:
+    """Login gate: collapse every violation into InvalidCredentialsError.
+
+    A login response must not confirm that an account exists or reveal its
+    state (anti-enumeration). Callers already holding a valid token get the
+    real reason instead - see ensure_can_use_session.
+    """
+    if account_access_violation(user) is not None:
+        raise InvalidCredentialsError(INVALID_CREDENTIALS_MESSAGE)
+
+
+def ensure_can_use_session(user: AccountLike) -> None:
+    """Gate for callers that already proved the account exists with a valid
+    token; masking would only hurt the client, so the reason is reported."""
+    violation = account_access_violation(user)
+    if violation is AccountAccessViolation.BLOCKED:
+        raise UserBlockedError("User is blocked")
+    if violation is AccountAccessViolation.NOT_VERIFIED:
+        raise UserNotVerifiedError("User is not verified")
+
+
+def verification_pending(user: AccountLike) -> bool:
+    """True while the account still needs email verification (resend flow)."""
+    return not user.is_verified

--- a/src/user/routers.py
+++ b/src/user/routers.py
@@ -16,6 +16,7 @@ from src.core.limiter.depends import RateLimiter
 from src.core.schemas import SuccessResponse
 from src.user.auth.cookies import TokenCookieResponder, get_token_cookie_responder
 from src.user.auth.dependencies import (
+    get_authenticated_user,
     get_current_user,
     get_user_id_from_token,
 )
@@ -52,7 +53,9 @@ router.include_router(auth_router, prefix="/auth")
     response_model=UserProfileViewModel,
 )
 async def get_user_profile(
-    current_user: Annotated[User, Depends(get_current_user)],
+    # Deliberate opt-out of the admission gate: a blocked or unverified account
+    # must still see its own is_verified / is_active state.
+    current_user: Annotated[User, Depends(get_authenticated_user)],
 ) -> UserProfileViewModel:
     """
     Returns the current user's information.

--- a/src/user/schemas.py
+++ b/src/user/schemas.py
@@ -21,6 +21,7 @@ class UserProfileViewModel(Base):
     email: EmailStr
     phone_number: str
     is_verified: bool
+    is_active: bool
 
 
 class UserSummaryViewModel(Base):

--- a/src/user/usecases/update_password.py
+++ b/src/user/usecases/update_password.py
@@ -10,13 +10,13 @@ from src.core.cache.interface import Cache
 from src.core.database.session import get_unit_of_work
 from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
 from src.core.errors.exceptions import (
-    AccessForbiddenException,
     InstanceNotFoundException,
     InstanceProcessingException,
 )
 from src.core.redis.dependencies import get_redis_client
 from src.core.schemas import SuccessResponse
 from src.core.utils.security import hash_password, mask_email, verify_password
+from src.user.auth.errors import InvalidCredentialsError
 from src.user.auth.schemas import UserNewPassword
 from src.user.auth.token_helpers import invalidate_all_user_sessions
 from src.user.cache_keys import user_cache_keys
@@ -57,7 +57,7 @@ class UpdateUserPasswordUseCase:
 
     Errors:
     - InstanceNotFoundException: if the user does not exist.
-    - AccessForbiddenException: if current_password does not match.
+    - InvalidCredentialsError: if current_password does not match.
     - InstanceProcessingException: if the new password repeats the current one.
 
     Returns:
@@ -86,7 +86,7 @@ class UpdateUserPasswordUseCase:
                     "[UpdateUserPassword] Wrong current password for %s.",
                     mask_email(user.email),
                 )
-                raise AccessForbiddenException("Current password is incorrect.")
+                raise InvalidCredentialsError("Current password is incorrect.")
 
             if data.password == data.current_password:
                 # Not a no-op: going through with it would still sign every

--- a/tests/unit/src/core/errors/test_error_handlers.py
+++ b/tests/unit/src/core/errors/test_error_handlers.py
@@ -14,7 +14,7 @@ from src.core.errors.handlers import (
     handle_request_validation_exception,
     handle_validation_error,
 )
-import src.user.auth.errors  # noqa: F401 - register domain subclasses for the walk
+import src.user.auth.errors  # noqa: F401 - register domain subclasses for the walk; every new domain errors module must be imported here the same way
 
 
 class SampleModel(BaseModel):
@@ -257,3 +257,12 @@ async def test_http_exception_handler_maps_5xx_to_internal_error() -> None:
     bad_gateway = HTTPException(status_code=502, detail="Bad Gateway")
     response = await handlers.handle_http_exception(make_request(), bad_gateway)
     assert json.loads(response.body)["code"] == "internal_error"
+
+
+async def test_http_exception_handler_omits_body_for_bodyless_status() -> None:
+    # 304 (and 204/1xx) must not carry a body; a JSON error payload there
+    # would be a protocol violation.
+    not_modified = HTTPException(status_code=304)
+    response = await handlers.handle_http_exception(make_request(), not_modified)
+    assert response.status_code == 304
+    assert response.body == b""

--- a/tests/unit/src/core/errors/test_error_handlers.py
+++ b/tests/unit/src/core/errors/test_error_handlers.py
@@ -1,26 +1,18 @@
 import json
 import logging
-from unittest.mock import MagicMock
 
 from fastapi import Request
 from fastapi.exceptions import RequestValidationError
 from pydantic import BaseModel, ValidationError
 import pytest
+import sentry_sdk
 
-from src.core.errors import handlers
-from src.core.errors.exceptions import (
-    AccessForbiddenException,
-    CoreException,
-    FilteringError,
-    InfrastructureException,
-    InstanceAlreadyExistsException,
-    InstanceNotFoundException,
-    InstanceProcessingException,
-    NotAcceptableException,
-    PayloadTooLargeException,
-    PermissionDeniedException,
-    TooManyRequestsException,
-    UnauthorizedException,
+from src.core.errors import exceptions as exc, handlers
+from src.core.errors.codes import ErrorCode
+from src.core.errors.handlers import (
+    handle_core_exception,
+    handle_request_validation_exception,
+    handle_validation_error,
 )
 
 
@@ -28,28 +20,7 @@ class SampleModel(BaseModel):
     field: int
 
 
-class LogMessageWithPath:
-    def __init__(self, original):
-        self._original = original
-
-    def __call__(
-        self,
-        request: Request,
-        error_type: str,
-        message: str | None,
-        additional_info: dict[str, object] | None = None,
-        include_request_path: bool = False,
-    ) -> str:
-        return self._original(
-            request,
-            error_type,
-            message,
-            additional_info,
-            include_request_path=True,
-        )
-
-
-def _build_request(headers: list[tuple[bytes, bytes]] | None = None) -> Request:
+def make_request(headers: list[tuple[bytes, bytes]] | None = None) -> Request:
     scope = {
         "type": "http",
         "method": "GET",
@@ -67,6 +38,26 @@ def _build_request(headers: list[tuple[bytes, bytes]] | None = None) -> Request:
     return Request(scope)
 
 
+def make_request_validation_error() -> RequestValidationError:
+    return RequestValidationError(
+        [
+            {
+                "loc": ("body", "field"),
+                "msg": "value is not a valid integer",
+                "type": "type_error.integer",
+            }
+        ]
+    )
+
+
+def make_pydantic_error() -> ValidationError:
+    try:
+        SampleModel.model_validate({"field": "bad"})
+    except ValidationError as error:
+        return error
+    raise AssertionError("expected ValidationError")
+
+
 @pytest.fixture(autouse=True)
 def _patch_response_logger(monkeypatch: pytest.MonkeyPatch) -> logging.Logger:
     logger = logging.getLogger("response_logger_test")
@@ -78,7 +69,7 @@ def _patch_response_logger(monkeypatch: pytest.MonkeyPatch) -> logging.Logger:
 
 
 def test_format_log_message_masks_sensitive_data() -> None:
-    request = _build_request(headers=[(b"x-request-id", b"req-123")])
+    request = make_request(headers=[(b"x-request-id", b"req-123")])
 
     message = handlers.format_log_message(
         request,
@@ -94,7 +85,7 @@ def test_format_log_message_masks_sensitive_data() -> None:
 
 
 def test_format_log_message_truncates_long_text() -> None:
-    request = _build_request()
+    request = make_request()
     long_message = "a" * 600
 
     message = handlers.format_log_message(request, "error", long_message)
@@ -103,226 +94,81 @@ def test_format_log_message_truncates_long_text() -> None:
     assert message.count("a") == 497
 
 
-@pytest.mark.asyncio
-async def test_core_exception_handler(caplog: pytest.LogCaptureFixture) -> None:
-    request = _build_request()
-    caplog.set_level(logging.INFO, logger="response_logger_test")
-
-    response = await handlers.handle_core_exception(
-        request,
-        CoreException("failed to process"),
+async def test_generic_handler_serializes_declared_status_and_code() -> None:
+    response = await handle_core_exception(
+        make_request(), exc.InstanceNotFoundException("User not found.")
     )
-
-    assert response.status_code == 400
+    assert response.status_code == 404
     assert json.loads(response.body) == {
-        "error": "Bad request",
-        "message": "failed to process",
-    }
-    assert any("Bad request" in record.message for record in caplog.records)
-
-
-@pytest.mark.asyncio
-async def test_filtering_error_handler_logs_warning(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    request = _build_request()
-    caplog.set_level(logging.WARNING, logger="response_logger_test")
-
-    response = await handlers.handle_filtering_error(
-        request,
-        FilteringError("invalid filter"),
-    )
-
-    assert response.status_code == 400
-    assert json.loads(response.body) == {
-        "error": "Filtering error",
-        "message": "invalid filter",
-    }
-    assert any(
-        record.levelno == logging.WARNING and "Filtering error" in record.message
-        for record in caplog.records
-    )
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "handler_fn,exc_cls,status,error_type,log_level,include_path",
-    [
-        (
-            handlers.handle_instance_not_found_exception,
-            InstanceNotFoundException,
-            404,
-            "Instance not found",
-            logging.INFO,
-            False,
-        ),
-        (
-            handlers.handle_instance_already_exists_exception,
-            InstanceAlreadyExistsException,
-            409,
-            "Instance already exists",
-            logging.INFO,
-            False,
-        ),
-        (
-            handlers.handle_instance_processing_exception,
-            InstanceProcessingException,
-            400,
-            "Instance processing error",
-            logging.INFO,
-            False,
-        ),
-        (
-            handlers.handle_unauthorized_exception,
-            UnauthorizedException,
-            401,
-            "Unauthorized",
-            logging.WARNING,
-            True,
-        ),
-        (
-            handlers.handle_access_forbidden_exception,
-            AccessForbiddenException,
-            403,
-            "Forbidden",
-            logging.WARNING,
-            True,
-        ),
-        (
-            handlers.handle_not_acceptable_exception,
-            NotAcceptableException,
-            406,
-            "Not Acceptable",
-            logging.INFO,
-            False,
-        ),
-        (
-            handlers.handle_permission_denied_exception,
-            PermissionDeniedException,
-            403,
-            "Permission Denied",
-            logging.WARNING,
-            True,
-        ),
-    ],
-)
-async def test_other_handlers(
-    handler_fn: handlers.HandlerCallable,
-    exc_cls: type[CoreException],
-    status: int,
-    error_type: str,
-    log_level: int,
-    include_path: bool,
-    caplog: pytest.LogCaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    request = _build_request()
-    caplog.set_level(log_level, logger="response_logger_test")
-
-    if include_path:
-        monkeypatch.setattr(
-            handlers,
-            "format_log_message",
-            LogMessageWithPath(handlers.format_log_message),
-        )
-
-    response = await handler_fn(request, exc_cls("failure"))
-
-    assert response.status_code == status
-    assert json.loads(response.body) == {"error": error_type, "message": "failure"}
-    assert any(
-        record.levelno == log_level and error_type in record.message
-        for record in caplog.records
-    )
-
-
-@pytest.mark.asyncio
-async def test_infrastructure_exception_handler_captures_sentry(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    request = _build_request()
-    capture = MagicMock()
-    monkeypatch.setattr(handlers.sentry_sdk, "capture_exception", capture)
-
-    response = await handlers.handle_infrastructure_exception(
-        request,
-        InfrastructureException("infra fail"),
-    )
-
-    assert response.status_code == 500
-    assert json.loads(response.body) == {
-        "error": "Infrastructure error",
-        "message": "infra fail",
-    }
-    capture.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_request_validation_exception_handler_returns_422() -> None:
-    request = _build_request()
-    exc = RequestValidationError(
-        [
-            {
-                "loc": ("body", "field"),
-                "msg": "value is not a valid integer",
-                "type": "type_error.integer",
-            }
-        ]
-    )
-
-    response = await handlers.handle_request_validation_exception(request, exc)
-
-    assert response.status_code == 422
-    payload = json.loads(response.body)
-    assert payload["detail"][0]["loc"] == ["body", "field"]
-    assert payload["detail"][0]["msg"] == "value is not a valid integer"
-
-
-@pytest.mark.asyncio
-async def test_validation_error_exception_handler_returns_500_and_captures(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    request = _build_request()
-    capture = MagicMock()
-    monkeypatch.setattr(handlers.sentry_sdk, "capture_exception", capture)
-
-    with pytest.raises(ValidationError) as exc_info:
-        SampleModel.model_validate({"field": "bad"})
-
-    response = await handlers.handle_validation_error(request, exc_info.value)
-
-    assert response.status_code == 500
-    assert json.loads(response.body) == {"detail": "Unexpected error"}
-    capture.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_payload_too_large_exception_handler_returns_413() -> None:
-    request = _build_request()
-
-    response = await handlers.handle_payload_too_large_exception(
-        request,
-        PayloadTooLargeException("too large"),
-    )
-
-    assert response.status_code == 413
-    assert json.loads(response.body) == {
-        "error": "Payload too large",
-        "message": "too large",
+        "code": "not_found",
+        "message": "User not found.",
     }
 
 
-@pytest.mark.asyncio
-async def test_too_many_requests_exception_handler_sets_retry_after() -> None:
-    request = _build_request()
+async def test_generic_handler_defaults_message() -> None:
+    response = await handle_core_exception(make_request(), exc.CoreException())
+    assert json.loads(response.body) == {
+        "code": "processing_error",
+        "message": "No additional details available",
+    }
 
-    response = await handlers.handle_too_many_requests_exception(
-        request, TooManyRequestsException("slow down", retry_after=5)
+
+async def test_generic_handler_emits_declared_headers_and_extras() -> None:
+    response = await handle_core_exception(
+        make_request(),
+        exc.TooManyRequestsException("Too many requests", retry_after=30),
     )
-
     assert response.status_code == 429
-    assert response.headers.get("Retry-After") == "5"
+    assert response.headers["Retry-After"] == "30"
     assert json.loads(response.body) == {
-        "error": "Too Many Requests",
-        "message": "slow down",
+        "code": "rate_limited",
+        "message": "Too many requests",
+        "retry_after": 30,
+    }
+
+
+async def test_generic_handler_captures_sentry_only_when_declared(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[BaseException] = []
+    monkeypatch.setattr(sentry_sdk, "capture_exception", captured.append)
+
+    await handle_core_exception(make_request(), exc.InfrastructureException("boom"))
+    assert len(captured) == 1
+
+    await handle_core_exception(make_request(), exc.ServiceUnavailableException("down"))
+    assert len(captured) == 1
+
+
+async def test_request_validation_handler_shapes_errors_list() -> None:
+    validation_error = make_request_validation_error()
+    response = await handle_request_validation_exception(
+        make_request(), validation_error
+    )
+    body = json.loads(response.body)
+    assert response.status_code == 422
+    assert body["code"] == "validation_error"
+    assert body["message"] == "Request validation failed"
+    assert all(set(item) == {"field", "message"} for item in body["errors"])
+
+
+async def test_backend_validation_handler_hides_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[BaseException] = []
+    monkeypatch.setattr(sentry_sdk, "capture_exception", captured.append)
+    response = await handle_validation_error(make_request(), make_pydantic_error())
+    assert response.status_code == 500
+    assert json.loads(response.body) == {
+        "code": "internal_error",
+        "message": "Unexpected error",
+    }
+    assert len(captured) == 1
+
+
+def test_format_error_response_defaults_message_when_blank() -> None:
+    body = handlers.format_error_response(ErrorCode.NOT_FOUND, None)
+    assert body == {
+        "code": ErrorCode.NOT_FOUND,
+        "message": "No additional details available",
     }

--- a/tests/unit/src/core/errors/test_error_handlers.py
+++ b/tests/unit/src/core/errors/test_error_handlers.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from pydantic import BaseModel, ValidationError
 import pytest
@@ -213,3 +213,47 @@ async def test_every_exception_answers_the_error_contract(
     assert set(body) - ALLOWED_EXTRA_KEYS == {"code", "message"}
     assert body["code"] in set(ErrorCode)
     assert response.status_code == exception_class.status_code
+
+
+async def test_http_exception_handler_translates_401_and_passes_headers() -> None:
+    # FastAPI's Security utilities raise a bare HTTPException when credentials
+    # are missing; this is the smoke-tested regression for GET /v1/users/me.
+    unauthenticated = HTTPException(
+        status_code=401,
+        detail="Not authenticated",
+        headers={"WWW-Authenticate": 'Basic realm="docs"'},
+    )
+    response = await handlers.handle_http_exception(make_request(), unauthenticated)
+    assert response.status_code == 401
+    assert json.loads(response.body) == {
+        "code": "unauthorized",
+        "message": "Not authenticated",
+    }
+    assert response.headers["WWW-Authenticate"] == 'Basic realm="docs"'
+
+
+async def test_http_exception_handler_translates_404() -> None:
+    # Starlette's router raises this for an unmatched path.
+    not_found = HTTPException(status_code=404, detail="Not Found")
+    response = await handlers.handle_http_exception(make_request(), not_found)
+    assert response.status_code == 404
+    assert json.loads(response.body) == {"code": "not_found", "message": "Not Found"}
+
+
+async def test_http_exception_handler_translates_405() -> None:
+    wrong_method = HTTPException(status_code=405, detail="Method Not Allowed")
+    response = await handlers.handle_http_exception(make_request(), wrong_method)
+    assert response.status_code == 405
+    assert json.loads(response.body)["code"] == "method_not_allowed"
+
+
+async def test_http_exception_handler_maps_unknown_status_to_processing_error() -> None:
+    teapot = HTTPException(status_code=418, detail="I'm a teapot")
+    response = await handlers.handle_http_exception(make_request(), teapot)
+    assert json.loads(response.body)["code"] == "processing_error"
+
+
+async def test_http_exception_handler_maps_5xx_to_internal_error() -> None:
+    bad_gateway = HTTPException(status_code=502, detail="Bad Gateway")
+    response = await handlers.handle_http_exception(make_request(), bad_gateway)
+    assert json.loads(response.body)["code"] == "internal_error"

--- a/tests/unit/src/core/errors/test_error_handlers.py
+++ b/tests/unit/src/core/errors/test_error_handlers.py
@@ -14,6 +14,7 @@ from src.core.errors.handlers import (
     handle_request_validation_exception,
     handle_validation_error,
 )
+import src.user.auth.errors  # noqa: F401 - register domain subclasses for the walk
 
 
 class SampleModel(BaseModel):
@@ -188,3 +189,27 @@ def test_format_error_response_defaults_message_when_blank() -> None:
         "code": ErrorCode.NOT_FOUND,
         "message": "No additional details available",
     }
+
+
+def _all_core_exception_classes() -> list[type[exc.CoreException]]:
+    found: list[type[exc.CoreException]] = []
+    stack: list[type[exc.CoreException]] = [exc.CoreException]
+    while stack:
+        current = stack.pop()
+        found.append(current)
+        stack.extend(current.__subclasses__())
+    return found
+
+
+ALLOWED_EXTRA_KEYS = {"retry_after", "errors"}
+
+
+@pytest.mark.parametrize("exception_class", _all_core_exception_classes())
+async def test_every_exception_answers_the_error_contract(
+    exception_class: type[exc.CoreException],
+) -> None:
+    response = await handle_core_exception(make_request(), exception_class("boom"))
+    body = json.loads(response.body)
+    assert set(body) - ALLOWED_EXTRA_KEYS == {"code", "message"}
+    assert body["code"] in set(ErrorCode)
+    assert response.status_code == exception_class.status_code

--- a/tests/unit/src/core/errors/test_error_handlers.py
+++ b/tests/unit/src/core/errors/test_error_handlers.py
@@ -152,6 +152,22 @@ async def test_request_validation_handler_shapes_errors_list() -> None:
     assert all(set(item) == {"field", "message"} for item in body["errors"])
 
 
+def test_format_validation_errors_keeps_non_leading_body_segment() -> None:
+    # Only the leading "body" prefix FastAPI adds is dropped; a field that is
+    # itself literally named "body" further down the path must survive.
+    errors = [
+        {
+            "loc": ("body", "payload", "body"),
+            "msg": "field required",
+            "type": "missing",
+        }
+    ]
+
+    formatted = handlers._format_validation_errors(errors)
+
+    assert formatted == [{"field": "payload.body", "message": "field required"}]
+
+
 async def test_backend_validation_handler_hides_details(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/src/core/errors/test_exception_contract.py
+++ b/tests/unit/src/core/errors/test_exception_contract.py
@@ -1,0 +1,49 @@
+import pytest
+
+from src.core.errors import exceptions as exc
+from src.core.errors.codes import ErrorCode
+
+
+@pytest.mark.parametrize(
+    ("exception_class", "status", "code"),
+    [
+        (exc.CoreException, 400, ErrorCode.PROCESSING_ERROR),
+        (exc.InfrastructureException, 500, ErrorCode.INFRASTRUCTURE_ERROR),
+        (exc.ServiceUnavailableException, 503, ErrorCode.SERVICE_UNAVAILABLE),
+        (exc.InstanceNotFoundException, 404, ErrorCode.NOT_FOUND),
+        (exc.InstanceProcessingException, 400, ErrorCode.PROCESSING_ERROR),
+        (exc.PayloadTooLargeException, 413, ErrorCode.PAYLOAD_TOO_LARGE),
+        (exc.FilteringError, 400, ErrorCode.INVALID_QUERY),
+        (exc.UnauthorizedException, 401, ErrorCode.UNAUTHORIZED),
+        (exc.AccessForbiddenException, 403, ErrorCode.FORBIDDEN),
+        (exc.TooManyRequestsException, 429, ErrorCode.RATE_LIMITED),
+    ],
+)
+def test_exception_declares_status_and_code(
+    exception_class: type[exc.CoreException], status: int, code: ErrorCode
+) -> None:
+    assert exception_class.status_code == status
+    assert exception_class.error_code is code
+
+
+def test_default_headers_and_extras_are_empty() -> None:
+    error = exc.InstanceNotFoundException("missing")
+    assert error.response_headers() == {}
+    assert error.body_extras() == {}
+
+
+def test_unauthorized_carries_www_authenticate_header() -> None:
+    error = exc.UnauthorizedException("nope", www_authenticate='Basic realm="docs"')
+    assert error.response_headers() == {"WWW-Authenticate": 'Basic realm="docs"'}
+
+
+def test_too_many_requests_carries_retry_after() -> None:
+    error = exc.TooManyRequestsException("slow down", retry_after=42)
+    assert error.response_headers() == {"Retry-After": "42"}
+    assert error.body_extras() == {"retry_after": 42}
+
+
+def test_sentry_capture_flag() -> None:
+    assert exc.InfrastructureException.capture_to_sentry is True
+    assert exc.ServiceUnavailableException.capture_to_sentry is False
+    assert exc.CoreException.capture_to_sentry is False

--- a/tests/unit/src/core/middleware/test_middleware_postgres.py
+++ b/tests/unit/src/core/middleware/test_middleware_postgres.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from sqlalchemy.exc import IntegrityError
 
@@ -45,6 +47,14 @@ class DummyCheckViolation:
         return "check violation"
 
 
+class DummyExclusionViolation:
+    sqlstate = "23P01"
+    detail = "Key (room_id, during)=(1, [09:00,10:00)) conflicts with existing key."
+
+    def __str__(self) -> str:
+        return "exclusion violation"
+
+
 class DummyUnknownViolation:
     sqlstate = "99999"
     detail = None
@@ -60,7 +70,10 @@ async def test_handle_postgresql_error_not_null_returns_500() -> None:
     result: PostgresqlErrorHandlingResult = handle_postgresql_error(err)
 
     assert result.response.status_code == 500
-    assert result.response.body == b'{"detail":"Unexpected error"}'
+    assert json.loads(result.response.body) == {
+        "code": "internal_error",
+        "message": "Unexpected error",
+    }
 
 
 @pytest.mark.asyncio
@@ -70,7 +83,21 @@ async def test_handle_postgresql_error_unique_violation_returns_409() -> None:
     result = handle_postgresql_error(err)
 
     assert result.response.status_code == 409
-    assert result.response.body == b'{"detail":"email"}'
+    assert json.loads(result.response.body) == {
+        "code": "already_exists",
+        "message": "Resource already exists.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_unique_violation_does_not_leak_the_conflicting_value() -> None:
+    err = IntegrityError("msg", None, DummyUniqueViolation())  # type: ignore[arg-type]
+
+    result = handle_postgresql_error(err)
+
+    body = json.loads(result.response.body)
+    assert body == {"code": "already_exists", "message": "Resource already exists."}
+    assert "user@example.com" not in result.response.body.decode()
 
 
 @pytest.mark.asyncio
@@ -80,10 +107,11 @@ async def test_handle_postgresql_error_foreign_key_violation_returns_400() -> No
     result = handle_postgresql_error(err)
 
     assert result.response.status_code == 400
-    assert (
-        result.response.body
-        == b'{"detail":"Key (user_id)=(1) is not present in table."}'
-    )
+    assert json.loads(result.response.body) == {
+        "code": "invalid_reference",
+        "message": "Referenced resource does not exist.",
+    }
+    assert "user_id" not in result.response.body.decode()
 
 
 @pytest.mark.asyncio
@@ -95,7 +123,10 @@ async def test_handle_postgresql_error_detail_fallback_from_raw_message() -> Non
     result = handle_postgresql_error(err)
 
     assert result.response.status_code == 400
-    assert result.response.body == b'{"detail":"missing reference"}'
+    assert json.loads(result.response.body) == {
+        "code": "invalid_reference",
+        "message": "Referenced resource does not exist.",
+    }
 
 
 @pytest.mark.asyncio
@@ -105,7 +136,24 @@ async def test_handle_postgresql_error_check_violation_returns_500() -> None:
     result = handle_postgresql_error(err)
 
     assert result.response.status_code == 500
-    assert result.response.body == b'{"detail":"Unexpected error"}'
+    assert json.loads(result.response.body) == {
+        "code": "internal_error",
+        "message": "Unexpected error",
+    }
+
+
+@pytest.mark.asyncio
+async def test_handle_postgresql_error_exclusion_violation_returns_500() -> None:
+    err = IntegrityError("msg", None, DummyExclusionViolation())  # type: ignore[arg-type]
+
+    result = handle_postgresql_error(err)
+
+    assert result.response.status_code == 500
+    assert json.loads(result.response.body) == {
+        "code": "internal_error",
+        "message": "Unexpected error",
+    }
+    assert "room_id" not in result.response.body.decode()
 
 
 @pytest.mark.asyncio
@@ -115,4 +163,7 @@ async def test_handle_postgresql_error_unknown_violation_returns_500() -> None:
     result = handle_postgresql_error(err)
 
     assert result.response.status_code == 500
-    assert result.response.body == b'{"detail":"Unexpected error"}'
+    assert json.loads(result.response.body) == {
+        "code": "internal_error",
+        "message": "Unexpected error",
+    }

--- a/tests/unit/src/core/middleware/test_middlewares_http.py
+++ b/tests/unit/src/core/middleware/test_middlewares_http.py
@@ -189,7 +189,11 @@ def test_integrity_unique_violation() -> None:
     resp = client.get("/boom")
 
     assert resp.status_code == 409
-    assert resp.json() == {"detail": "email"}
+    assert resp.json() == {
+        "code": "already_exists",
+        "message": "Resource already exists.",
+    }
+    assert "test@example.com" not in resp.text
 
 
 def test_integrity_not_null_violation() -> None:
@@ -199,7 +203,10 @@ def test_integrity_not_null_violation() -> None:
     resp = client.get("/boom")
 
     assert resp.status_code == 500
-    assert resp.json() == {"detail": middleware.UNEXPECTED_ERROR_DETAIL}
+    assert resp.json() == {
+        "code": "internal_error",
+        "message": middleware.UNEXPECTED_ERROR_DETAIL,
+    }
 
 
 def test_integrity_foreign_key_violation() -> None:
@@ -209,7 +216,10 @@ def test_integrity_foreign_key_violation() -> None:
     resp = client.get("/boom")
 
     assert resp.status_code == 400
-    assert resp.json() == {"detail": DummyForeignKey.detail}
+    assert resp.json() == {
+        "code": "invalid_reference",
+        "message": "Referenced resource does not exist.",
+    }
 
 
 def test_integrity_check_violation() -> None:
@@ -219,7 +229,10 @@ def test_integrity_check_violation() -> None:
     resp = client.get("/boom")
 
     assert resp.status_code == 500
-    assert resp.json() == {"detail": middleware.UNEXPECTED_ERROR_DETAIL}
+    assert resp.json() == {
+        "code": "internal_error",
+        "message": middleware.UNEXPECTED_ERROR_DETAIL,
+    }
 
 
 def test_integrity_unknown_violation_defaults_to_500() -> None:
@@ -229,7 +242,10 @@ def test_integrity_unknown_violation_defaults_to_500() -> None:
     resp = client.get("/boom")
 
     assert resp.status_code == 500
-    assert resp.json() == {"detail": middleware.UNEXPECTED_ERROR_DETAIL}
+    assert resp.json() == {
+        "code": "internal_error",
+        "message": middleware.UNEXPECTED_ERROR_DETAIL,
+    }
 
 
 def test_operational_error() -> None:
@@ -238,9 +254,10 @@ def test_operational_error() -> None:
 
     resp = client.get("/boom")
 
-    assert resp.status_code == 500
+    assert resp.status_code == 503
     assert resp.json() == {
-        "detail": "Database connection error. Please try again later."
+        "code": "service_unavailable",
+        "message": "Database is temporarily unavailable. Please try again later.",
     }
 
 
@@ -251,7 +268,10 @@ def test_programming_error() -> None:
     resp = client.get("/boom")
 
     assert resp.status_code == 500
-    assert resp.json() == {"detail": "Database query error."}
+    assert resp.json() == {
+        "code": "internal_error",
+        "message": middleware.UNEXPECTED_ERROR_DETAIL,
+    }
 
 
 def test_unexpected_error_middleware() -> None:
@@ -267,7 +287,10 @@ def test_unexpected_error_middleware() -> None:
     resp = client.get("/boom")
 
     assert resp.status_code == 500
-    assert resp.json() == {"detail": middleware.UNEXPECTED_ERROR_DETAIL}
+    assert resp.json() == {
+        "code": "internal_error",
+        "message": middleware.UNEXPECTED_ERROR_DETAIL,
+    }
 
 
 def test_cached_statement_plan_error_is_not_retried() -> None:
@@ -277,7 +300,10 @@ def test_cached_statement_plan_error_is_not_retried() -> None:
     resp = client.get("/cached-statement-plan")
 
     assert resp.status_code == 500
-    assert resp.json() == {"detail": middleware.UNEXPECTED_ERROR_DETAIL}
+    assert resp.json() == {
+        "code": "internal_error",
+        "message": middleware.UNEXPECTED_ERROR_DETAIL,
+    }
     assert app.state.cached_statement_attempts == 1
 
 
@@ -287,9 +313,10 @@ def test_invalidated_connection_error_is_not_retried() -> None:
 
     resp = client.get("/invalidated-connection")
 
-    assert resp.status_code == 500
+    assert resp.status_code == 503
     assert resp.json() == {
-        "detail": "Database connection error. Please try again later."
+        "code": "service_unavailable",
+        "message": "Database is temporarily unavailable. Please try again later.",
     }
     assert app.state.invalidated_connection_attempts == 1
 
@@ -301,5 +328,8 @@ def test_database_error_middleware_does_not_retry_integrity_error() -> None:
     resp = client.get("/integrity-error")
 
     assert resp.status_code == 500
-    assert resp.json() == {"detail": middleware.UNEXPECTED_ERROR_DETAIL}
+    assert resp.json() == {
+        "code": "internal_error",
+        "message": middleware.UNEXPECTED_ERROR_DETAIL,
+    }
     assert app.state.integrity_attempts == 1

--- a/tests/unit/src/main/test_http_exception_contract.py
+++ b/tests/unit/src/main/test_http_exception_contract.py
@@ -1,0 +1,36 @@
+"""
+Live smoke found two framework-raised HTTPExceptions that bypassed the error
+contract entirely: FastAPI's Security utilities answer missing credentials
+with a bare {"detail": "Not authenticated"} body, and Starlette's router
+answers an unmatched path with {"detail": "Not Found"}. Both must come back
+as the flat {"code", "message"} contract like every other error.
+
+Uses the plain `async_client` fixture (real `app`, no dependency overrides)
+because `app_with_fakes` overrides get_session/get_redis_client/etc. but not
+the security dependency itself - GET /v1/users/me's only dependency is
+`get_authenticated_user`, whose first sub-dependency is the Security(header)
+check, so it fails before touching the database and needs no overrides.
+"""
+
+import httpx2
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_unmatched_route_answers_the_error_contract(
+    async_client: httpx2.AsyncClient,
+) -> None:
+    response = await async_client.get("/nonexistent")
+
+    assert response.status_code == 404
+    assert response.json() == {"code": "not_found", "message": "Not Found"}
+
+
+@pytest.mark.asyncio
+async def test_missing_credentials_answers_the_error_contract(
+    async_client: httpx2.AsyncClient,
+) -> None:
+    response = await async_client.get("/v1/users/me")
+
+    assert response.status_code == 401
+    assert response.json() == {"code": "unauthorized", "message": "Not authenticated"}

--- a/tests/unit/src/main/test_presentation_web.py
+++ b/tests/unit/src/main/test_presentation_web.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 import pytest
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 
-from src.core.errors.exceptions import UnauthorizedException
+from src.core.errors.exceptions import CoreException
 from src.core.middleware import DOCS_CONTENT_SECURITY_POLICY
 from src.main.config import config
 from src.main.presentation import include_exceptions_handlers, include_routers
@@ -31,7 +31,9 @@ def test_include_exceptions_handlers_registers_handlers() -> None:
     app = FastAPI()
     include_exceptions_handlers(app)
 
-    assert UnauthorizedException in app.exception_handlers
+    # Starlette resolves handlers over the exception's MRO, so registering
+    # CoreException alone covers every subclass, e.g. UnauthorizedException.
+    assert CoreException in app.exception_handlers
 
 
 def test_get_application_registers_middlewares() -> None:

--- a/tests/unit/src/system/test_system_routers.py
+++ b/tests/unit/src/system/test_system_routers.py
@@ -97,7 +97,7 @@ async def test_check_readiness_returns_503_when_database_is_down(
         response = await client.get("/ready/")
 
         assert response.status_code == 503
-        assert response.json()["error"] == "Service unavailable"
+        assert response.json()["code"] == "service_unavailable"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/src/user/auth/test_auth_contract_flows.py
+++ b/tests/unit/src/user/auth/test_auth_contract_flows.py
@@ -5,7 +5,10 @@ import pytest
 
 from src.core.errors.exceptions import UnauthorizedException
 from src.core.schemas import SuccessResponse, TokenModel
-from src.user.auth.dependencies import get_access_by_refresh_token, get_current_user
+from src.user.auth.dependencies import (
+    get_access_by_refresh_token,
+    get_authenticated_user,
+)
 from src.user.auth.jwt_payload_schema import JWTPayload
 from src.user.auth.schemas import (
     LoginUserModel,
@@ -168,7 +171,9 @@ async def test_login_refresh_access_flow(
         get_tokens_by_refresh_user_use_case, ProvideValue(refresh_use_case)
     )
     dependency_overrides.set(get_access_by_refresh_token, refresh_dependency)
-    dependency_overrides.set(get_current_user, access_dependency)
+    # GET /users/me opts out of the admission gate (get_authenticated_user), so it is
+    # the dependency this end-to-end flow must authorize against, not get_current_user.
+    dependency_overrides.set(get_authenticated_user, access_dependency)
 
     # X-Token-Transport: body keeps the refresh token in the JSON body so this flow
     # can forward it via the Authorization header, exactly as a native client would.

--- a/tests/unit/src/user/auth/test_auth_dependencies.py
+++ b/tests/unit/src/user/auth/test_auth_dependencies.py
@@ -7,7 +7,8 @@ import jwt
 import pytest
 from starlette.requests import Request as StarletteRequest
 
-from src.core.errors.exceptions import AccessForbiddenException, UnauthorizedException
+from src.core.errors.codes import ErrorCode
+from src.core.errors.exceptions import UnauthorizedException
 from src.main.config import CookieConfig, config
 from src.user.auth import dependencies
 from src.user.auth.cookies import (
@@ -27,6 +28,7 @@ from src.user.auth.dependencies import (
     verify_csrf,
     verify_jti,
 )
+from src.user.auth.errors import CsrfFailedError, TokenExpiredError
 from src.user.auth.redis_keys import auth_redis_keys
 from src.user.models import User
 from tests.factories.token_factory import (
@@ -70,8 +72,10 @@ async def test_verify_jti_expired_token(fake_redis: InMemoryRedis) -> None:
     payload["exp"] = int((datetime.now(timezone.utc) - timedelta(hours=1)).timestamp())
     token = encode_token(payload, config.jwt.JWT_USER_SECRET_KEY)
 
-    with pytest.raises(UnauthorizedException, match="Token expired"):
+    with pytest.raises(TokenExpiredError, match="Token expired") as exc_info:
         await verify_jti(token, fake_redis)
+
+    assert exc_info.value.error_code is ErrorCode.TOKEN_EXPIRED
 
 
 @pytest.mark.asyncio
@@ -350,7 +354,7 @@ async def test_verify_csrf_rejects_cookie_credentials_with_missing_csrf_token() 
     request = _csrf_request(cookie="refresh-token-value")
     credentials = RefreshCredentials(token="refresh-token-value", from_cookie=True)
 
-    with pytest.raises(AccessForbiddenException):
+    with pytest.raises(CsrfFailedError):
         await verify_csrf(request, credentials, _refresh_responder())
 
 
@@ -361,7 +365,7 @@ async def test_verify_csrf_rejects_cookie_credentials_with_wrong_csrf_token() ->
     )
     credentials = RefreshCredentials(token="refresh-token-value", from_cookie=True)
 
-    with pytest.raises(AccessForbiddenException):
+    with pytest.raises(CsrfFailedError):
         await verify_csrf(request, credentials, _refresh_responder())
 
 
@@ -398,7 +402,7 @@ async def test_verify_csrf_ignores_a_declared_body_transport_for_a_cookie_borne_
     request = _csrf_request(cookie="refresh-token-value", declared_transport="body")
     credentials = RefreshCredentials(token="refresh-token-value", from_cookie=True)
 
-    with pytest.raises(AccessForbiddenException):
+    with pytest.raises(CsrfFailedError):
         await verify_csrf(request, credentials, _refresh_responder())
 
 

--- a/tests/unit/src/user/auth/test_auth_dependencies.py
+++ b/tests/unit/src/user/auth/test_auth_dependencies.py
@@ -20,7 +20,9 @@ from src.user.auth.csrf import build_csrf_token
 from src.user.auth.dependencies import (
     AuthenticatedUser,
     RefreshCredentials,
+    authenticate_access_token,
     get_access_by_refresh_token,
+    get_authenticated_user,
     get_current_user,
     get_current_user_with_session,
     get_user_id_from_token,
@@ -28,7 +30,12 @@ from src.user.auth.dependencies import (
     verify_csrf,
     verify_jti,
 )
-from src.user.auth.errors import CsrfFailedError, TokenExpiredError
+from src.user.auth.errors import (
+    CsrfFailedError,
+    TokenExpiredError,
+    UserBlockedError,
+    UserNotVerifiedError,
+)
 from src.user.auth.redis_keys import auth_redis_keys
 from src.user.models import User
 from tests.factories.token_factory import (
@@ -140,7 +147,7 @@ async def test_verify_jti_active_token_mismatch(fake_redis: InMemoryRedis) -> No
 
 
 @pytest.mark.asyncio
-async def test_get_current_user_success(
+async def test_authenticate_access_token_success(
     fake_redis: InMemoryRedis,
     fake_session: FakeAsyncSession,
 ) -> None:
@@ -154,34 +161,7 @@ async def test_get_current_user_success(
     )
     user_repository = FakeUserRepository(user)
 
-    result = await get_current_user(
-        token=token,
-        session=fake_session,
-        redis_client=fake_redis,
-        user_repository=user_repository,
-    )
-
-    assert isinstance(result, User)
-    assert result.id == user.id
-    user_repository.get_single.assert_awaited_once_with(fake_session, id=str(user.id))
-
-
-@pytest.mark.asyncio
-async def test_get_current_user_with_session_success(
-    fake_redis: InMemoryRedis,
-    fake_session: FakeAsyncSession,
-) -> None:
-    user = build_user()
-    payload = build_access_payload(str(user.id))
-    token = encode_token(payload, config.jwt.JWT_USER_SECRET_KEY)
-    await fake_redis.set(
-        auth_redis_keys.access(payload["sub"], payload["session_id"]),
-        payload["jti"],
-        ex=60,
-    )
-    user_repository = FakeUserRepository(user)
-
-    result = await get_current_user_with_session(
+    result = await authenticate_access_token(
         token=token,
         session=fake_session,
         redis_client=fake_redis,
@@ -195,7 +175,7 @@ async def test_get_current_user_with_session_success(
 
 
 @pytest.mark.asyncio
-async def test_get_current_user_wrong_mode(
+async def test_authenticate_access_token_wrong_mode(
     fake_redis: InMemoryRedis, fake_session: FakeAsyncSession
 ) -> None:
     payload = build_refresh_payload("user-1")
@@ -207,12 +187,82 @@ async def test_get_current_user_wrong_mode(
     )
 
     with pytest.raises(UnauthorizedException):
-        await get_current_user(
+        await authenticate_access_token(
             token=token,
             session=fake_session,
             redis_client=fake_redis,
             user_repository=FakeUserRepository(None),
         )
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_returns_user_when_admitted() -> None:
+    user = build_user()
+    authenticated = AuthenticatedUser(user=user, session_id="sid")
+
+    result = await get_current_user(authenticated)
+
+    assert isinstance(result, User)
+    assert result.id == user.id
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_blocks_inactive_user() -> None:
+    blocked = build_user(is_active=False)
+    authenticated = AuthenticatedUser(user=blocked, session_id="sid")
+
+    with pytest.raises(UserBlockedError):
+        await get_current_user(authenticated)
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_blocks_unverified_user() -> None:
+    unverified = build_user(is_verified=False)
+    authenticated = AuthenticatedUser(user=unverified, session_id="sid")
+
+    with pytest.raises(UserNotVerifiedError):
+        await get_current_user(authenticated)
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_with_session_returns_when_admitted() -> None:
+    user = build_user()
+    authenticated = AuthenticatedUser(user=user, session_id="sid")
+
+    result = await get_current_user_with_session(authenticated)
+
+    assert result is authenticated
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_with_session_blocks_inactive_user() -> None:
+    blocked = build_user(is_active=False)
+    authenticated = AuthenticatedUser(user=blocked, session_id="sid")
+
+    with pytest.raises(UserBlockedError):
+        await get_current_user_with_session(authenticated)
+
+
+@pytest.mark.asyncio
+async def test_get_authenticated_user_bypasses_the_gate_for_a_blocked_user() -> None:
+    blocked = build_user(is_active=False)
+    authenticated = AuthenticatedUser(user=blocked, session_id="sid")
+
+    result = await get_authenticated_user(authenticated)
+
+    assert result is blocked
+
+
+@pytest.mark.asyncio
+async def test_get_authenticated_user_bypasses_the_gate_for_an_unverified_user() -> (
+    None
+):
+    unverified = build_user(is_verified=False)
+    authenticated = AuthenticatedUser(user=unverified, session_id="sid")
+
+    result = await get_authenticated_user(authenticated)
+
+    assert result is unverified
 
 
 @pytest.mark.asyncio

--- a/tests/unit/src/user/auth/test_auth_routers.py
+++ b/tests/unit/src/user/auth/test_auth_routers.py
@@ -5,7 +5,9 @@ from unittest.mock import AsyncMock
 from fastapi.routing import APIRoute
 import pytest
 
+from src.core.database.session import get_unit_of_work
 from src.core.limiter.depends import RateLimiter
+from src.core.redis.dependencies import get_redis_client
 from src.core.schemas import SuccessResponse, TokenModel
 from src.user.auth.cookies import CSRF_COOKIE_NAME, REFRESH_COOKIE_NAME
 from src.user.auth.dependencies import (
@@ -36,14 +38,21 @@ from tests.factories.token_factory import (
     encode_access_payload,
 )
 from tests.factories.user_factory import build_user
+from tests.fakes.db import FakeAsyncSession, FakeUnitOfWork
+from tests.fakes.redis import InMemoryRedis
 from tests.helpers.limiter import noop_rate_limiter
 from tests.helpers.overrides import DependencyOverrides
-from tests.helpers.providers import ProvideValue
+from tests.helpers.providers import ProvideAsyncValue, ProvideValue
 
 
 class FakeUseCase:
     def __init__(self, result) -> None:
         self.execute = AsyncMock(return_value=result)
+
+
+class FakeUserRepository:
+    def __init__(self, user) -> None:
+        self.get_single = AsyncMock(return_value=user)
 
 
 def _get_auth_route(*, path: str, method: str) -> APIRoute:
@@ -143,6 +152,80 @@ async def test_refresh_endpoint(
     assert body["access_token"] == "a"
     assert body["refresh_token"] is None
     assert body["csrf_token"]
+
+
+@pytest.mark.asyncio
+async def test_login_of_blocked_user_masks_the_reason(
+    async_client,
+    dependency_overrides: DependencyOverrides,
+    fake_redis: InMemoryRedis,
+) -> None:
+    # The real LoginUserUseCase must run here (not FakeUseCase) so the assertion
+    # proves the route surfaces exactly what the use case raises for a blocked
+    # account - the same masked response as any other invalid credentials.
+    user = build_user(is_active=False)
+    uow = FakeUnitOfWork(
+        session=FakeAsyncSession(),
+        repositories={"users": FakeUserRepository(user)},
+    )
+    dependency_overrides.set(get_unit_of_work, ProvideAsyncValue(uow))
+    dependency_overrides.set(get_redis_client, ProvideValue(fake_redis))
+
+    response = await async_client.post(
+        "/v1/users/auth/login",
+        json={"email": user.email, "password": "password"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "code": "invalid_credentials",
+        "message": "Incorrect email or password.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_refresh_of_blocked_user_reports_user_blocked(
+    async_client,
+    dependency_overrides: DependencyOverrides,
+    fake_redis: InMemoryRedis,
+) -> None:
+    # The real GetTokensByRefreshUserUseCase must run here too: a caller who
+    # already holds a valid refresh token gets the real reason, unlike login.
+    user = build_user(is_active=False)
+    payload: JWTPayload = build_refresh_payload(str(user.id))
+    dependency_overrides.set(get_access_by_refresh_token, ProvideValue((user, payload)))
+    dependency_overrides.set(get_redis_client, ProvideValue(fake_redis))
+
+    response = await async_client.post(
+        "/v1/users/auth/login/refresh",
+        headers={"Authorization": "header-refresh-token"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"code": "user_blocked", "message": "User is blocked"}
+
+
+@pytest.mark.asyncio
+async def test_refresh_of_unverified_user_reports_user_not_verified(
+    async_client,
+    dependency_overrides: DependencyOverrides,
+    fake_redis: InMemoryRedis,
+) -> None:
+    user = build_user(is_verified=False)
+    payload: JWTPayload = build_refresh_payload(str(user.id))
+    dependency_overrides.set(get_access_by_refresh_token, ProvideValue((user, payload)))
+    dependency_overrides.set(get_redis_client, ProvideValue(fake_redis))
+
+    response = await async_client.post(
+        "/v1/users/auth/login/refresh",
+        headers={"Authorization": "header-refresh-token"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "code": "user_not_verified",
+        "message": "User is not verified",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/src/user/auth/test_cookies.py
+++ b/tests/unit/src/user/auth/test_cookies.py
@@ -1,18 +1,25 @@
+import json
+
 from fastapi import Response
 import pytest
 
-from src.core.errors.exceptions import AccessForbiddenException, InfrastructureException
+from src.core.errors.codes import ErrorCode
+from src.core.errors.exceptions import InfrastructureException
+from src.core.errors.handlers import handle_core_exception
 from src.core.schemas import TokenModel
 from src.main.config import CookieConfig
 from src.user.auth.cookies import (
     CSRF_COOKIE_NAME,
     CSRF_COOKIE_PATH,
+    CSRF_FAILURE_MESSAGE,
     REFRESH_COOKIE_NAME,
     REFRESH_COOKIE_PATH,
     TokenCookieResponder,
 )
 from src.user.auth.csrf import build_csrf_token
+from src.user.auth.errors import CsrfFailedError
 from src.user.auth.token_transport import TokenTransport
+from tests.helpers.requests import build_request
 
 SECRET = "unit-test-csrf-secret-key-value-32"
 
@@ -187,12 +194,29 @@ def test_verify_csrf_accepts_a_valid_pair(responder: TokenCookieResponder) -> No
 
 
 def test_verify_csrf_rejects_a_missing_header(responder: TokenCookieResponder) -> None:
-    with pytest.raises(AccessForbiddenException):
+    with pytest.raises(CsrfFailedError):
         responder.verify_csrf("r", None)
 
 
 def test_verify_csrf_rejects_a_wrong_signature(
     responder: TokenCookieResponder,
 ) -> None:
-    with pytest.raises(AccessForbiddenException):
+    with pytest.raises(CsrfFailedError):
         responder.verify_csrf("r", build_csrf_token("other", SECRET))
+
+
+async def test_verify_csrf_failure_serializes_to_csrf_failed_body(
+    responder: TokenCookieResponder,
+) -> None:
+    with pytest.raises(CsrfFailedError) as exc_info:
+        responder.verify_csrf("r", None)
+
+    assert exc_info.value.error_code is ErrorCode.CSRF_FAILED
+
+    response = await handle_core_exception(build_request(), exc_info.value)
+
+    assert response.status_code == 403
+    assert json.loads(response.body) == {
+        "code": "csrf_failed",
+        "message": CSRF_FAILURE_MESSAGE,
+    }

--- a/tests/unit/src/user/auth/test_errors.py
+++ b/tests/unit/src/user/auth/test_errors.py
@@ -1,0 +1,24 @@
+import pytest
+
+from src.core.errors.codes import ErrorCode
+from src.user.auth import errors
+
+
+@pytest.mark.parametrize(
+    ("error_class", "status", "code"),
+    [
+        (errors.UserBlockedError, 403, ErrorCode.USER_BLOCKED),
+        (errors.UserNotVerifiedError, 403, ErrorCode.USER_NOT_VERIFIED),
+        (errors.PermissionDeniedError, 403, ErrorCode.PERMISSION_DENIED),
+        (errors.CsrfFailedError, 403, ErrorCode.CSRF_FAILED),
+        (errors.TokenExpiredError, 401, ErrorCode.TOKEN_EXPIRED),
+        (errors.InvalidCredentialsError, 400, ErrorCode.INVALID_CREDENTIALS),
+    ],
+)
+def test_domain_error_declares_status_and_code(error_class, status, code) -> None:
+    assert error_class.status_code == status
+    assert error_class.error_code is code
+
+
+def test_invalid_credentials_logs_at_debug() -> None:
+    assert errors.InvalidCredentialsError.log_level == "debug"

--- a/tests/unit/src/user/auth/usecases/test_auth_usecases_stage1.py
+++ b/tests/unit/src/user/auth/usecases/test_auth_usecases_stage1.py
@@ -7,13 +7,11 @@ import jwt
 import pytest
 
 from src.core.cache.memory_cache import InMemoryCache
-from src.core.errors.exceptions import (
-    InstanceProcessingException,
-    PermissionDeniedException,
-)
+from src.core.errors.exceptions import InstanceProcessingException
 from src.core.schemas import SuccessResponse, TokenModel
 from src.core.utils.security import build_email_throttle_key
 from src.main.config import config
+from src.user.auth.errors import UserBlockedError, UserNotVerifiedError
 from src.user.auth.redis_keys import auth_redis_keys
 from src.user.auth.schemas import (
     CreateUserModel,
@@ -142,7 +140,7 @@ async def test_get_tokens_by_refresh_user_usecase_blocked(
 
     use_case = GetTokensByRefreshUserUseCase(redis_client=fake_redis)
 
-    with pytest.raises(PermissionDeniedException, match="User is blocked"):
+    with pytest.raises(UserBlockedError, match="User is blocked"):
         await use_case.execute(user=user, old_token_payload=payload)
 
 
@@ -155,7 +153,7 @@ async def test_get_tokens_by_refresh_user_usecase_unverified(
 
     use_case = GetTokensByRefreshUserUseCase(redis_client=fake_redis)
 
-    with pytest.raises(InstanceProcessingException, match="User is not verified"):
+    with pytest.raises(UserNotVerifiedError, match="User is not verified"):
         await use_case.execute(user=user, old_token_payload=payload)
 
 

--- a/tests/unit/src/user/auth/usecases/test_login_usecase_rehash.py
+++ b/tests/unit/src/user/auth/usecases/test_login_usecase_rehash.py
@@ -13,6 +13,7 @@ from src.user.auth.usecases.login import (
 )
 from src.user.cache_keys import user_cache_keys
 from src.user.models import User
+from src.user.policies import AccountAccessViolation
 from tests.factories.user_factory import build_user
 from tests.fakes.db import FakeAsyncSession, FakeUnitOfWork
 from tests.fakes.redis import InMemoryRedis
@@ -180,15 +181,15 @@ async def test_login_returns_unified_error_for_wrong_password(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("user", "expected_log_fragment"),
+    ("user", "expected_violation"),
     [
-        (build_user(is_verified=False), "not verified"),
-        (build_user(is_verified=True, is_active=False), "is blocked"),
+        (build_user(is_verified=False), AccountAccessViolation.NOT_VERIFIED),
+        (build_user(is_verified=True, is_active=False), AccountAccessViolation.BLOCKED),
     ],
 )
 async def test_login_returns_unified_error_for_account_state_failures(
     user: User,
-    expected_log_fragment: str,
+    expected_violation: AccountAccessViolation,
     monkeypatch: pytest.MonkeyPatch,
     fake_session: FakeAsyncSession,
     fake_redis: InMemoryRedis,
@@ -211,5 +212,8 @@ async def test_login_returns_unified_error_for_account_state_failures(
     uow.users.update.assert_not_awaited()
     uow.flush.assert_not_awaited()
     uow.commit.assert_not_awaited()
-    debug_mock.assert_called_once()
-    assert expected_log_fragment in debug_mock.call_args.args[0]
+    debug_mock.assert_called_once_with(
+        "[LoginUser] Account of '%s' fails admission (%s).",
+        "us***@ex***",
+        expected_violation,
+    )

--- a/tests/unit/src/user/test_policies.py
+++ b/tests/unit/src/user/test_policies.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+import inspect
+
+import pytest
+
+from src.user import policies
+from src.user.auth.errors import (
+    InvalidCredentialsError,
+    UserBlockedError,
+    UserNotVerifiedError,
+)
+
+
+@dataclass
+class StubAccount:
+    is_active: bool = True
+    is_verified: bool = True
+
+
+def test_admitted_account_has_no_violation() -> None:
+    assert policies.account_access_violation(StubAccount()) is None
+
+
+def test_blocked_wins_over_unverified() -> None:
+    account = StubAccount(is_active=False, is_verified=False)
+    violation = policies.account_access_violation(account)
+    assert violation is policies.AccountAccessViolation.BLOCKED
+
+
+def test_login_masks_every_violation() -> None:
+    with pytest.raises(InvalidCredentialsError) as excinfo:
+        policies.ensure_can_authenticate(StubAccount(is_active=False))
+    assert excinfo.value.message == policies.INVALID_CREDENTIALS_MESSAGE
+    with pytest.raises(InvalidCredentialsError):
+        policies.ensure_can_authenticate(StubAccount(is_verified=False))
+
+
+def test_session_gate_reports_the_reason() -> None:
+    with pytest.raises(UserBlockedError):
+        policies.ensure_can_use_session(StubAccount(is_active=False))
+    with pytest.raises(UserNotVerifiedError):
+        policies.ensure_can_use_session(StubAccount(is_verified=False))
+
+
+def test_admitted_account_passes_both_gates() -> None:
+    policies.ensure_can_authenticate(StubAccount())
+    policies.ensure_can_use_session(StubAccount())
+
+
+def test_verification_pending() -> None:
+    assert policies.verification_pending(StubAccount(is_verified=False)) is True
+    assert policies.verification_pending(StubAccount()) is False
+
+
+def test_policies_module_stays_pure() -> None:
+    source = inspect.getsource(policies)
+    import_lines = [
+        line for line in source.splitlines() if line.startswith(("import ", "from "))
+    ]
+    for line in import_lines:
+        assert not any(
+            name in line
+            for name in ("fastapi", "redis", "sqlalchemy", "src.core.database")
+        ), line

--- a/tests/unit/src/user/test_user_routes.py
+++ b/tests/unit/src/user/test_user_routes.py
@@ -10,7 +10,12 @@ from src.core.errors.exceptions import (
     InstanceProcessingException,
 )
 from src.core.schemas import SuccessResponse
-from src.user.auth.dependencies import get_current_user
+from src.user.auth.dependencies import (
+    AuthenticatedUser,
+    authenticate_access_token,
+    get_authenticated_user,
+    get_current_user,
+)
 from src.user.auth.errors import InvalidCredentialsError
 from src.user.auth.token_transport import TokenTransport, get_token_transport
 from src.user.dependencies import get_user_service
@@ -69,7 +74,7 @@ async def test_get_user_profile(
     dependency_overrides: DependencyOverrides,
 ) -> None:
     user = build_user()
-    dependency_overrides.set(get_current_user, ProvideValue(user))
+    dependency_overrides.set(get_authenticated_user, ProvideValue(user))
 
     response = await async_client.get("/v1/users/me")
 
@@ -322,3 +327,54 @@ async def test_update_user_profile_rejects_invalid_payloads(
     response = await async_client.patch("/v1/users/me", json=payload)
 
     assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_blocked_user_cannot_update_profile(
+    async_client, dependency_overrides: DependencyOverrides
+) -> None:
+    blocked = build_user(is_active=False)
+    dependency_overrides.set(
+        authenticate_access_token,
+        ProvideValue(AuthenticatedUser(user=blocked, session_id="sid")),
+    )
+
+    response = await async_client.patch("/v1/users/me", json={"username": "new-name"})
+
+    assert response.status_code == 403
+    assert response.json() == {"code": "user_blocked", "message": "User is blocked"}
+
+
+@pytest.mark.asyncio
+async def test_blocked_user_cannot_change_password(
+    async_client, dependency_overrides: DependencyOverrides
+) -> None:
+    blocked = build_user(is_active=False)
+    dependency_overrides.set(
+        authenticate_access_token,
+        ProvideValue(AuthenticatedUser(user=blocked, session_id="sid")),
+    )
+
+    response = await async_client.patch(
+        "/v1/users/me/password",
+        json={"current_password": "Current-1", "password": "Password-1"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["code"] == "user_blocked"
+
+
+@pytest.mark.asyncio
+async def test_unverified_user_still_reads_own_profile(
+    async_client, dependency_overrides: DependencyOverrides
+) -> None:
+    unverified = build_user(is_verified=False)
+    dependency_overrides.set(
+        authenticate_access_token,
+        ProvideValue(AuthenticatedUser(user=unverified, session_id="sid")),
+    )
+
+    response = await async_client.get("/v1/users/me")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == str(unverified.id)

--- a/tests/unit/src/user/test_user_routes.py
+++ b/tests/unit/src/user/test_user_routes.py
@@ -82,6 +82,25 @@ async def test_get_user_profile(
     payload = response.json()
     assert payload["id"] == str(user.id)
     assert payload["email"] == user.email
+    assert payload["is_active"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_user_profile_exposes_blocked_state(
+    async_client,
+    dependency_overrides: DependencyOverrides,
+) -> None:
+    """The /me admission opt-out exists so a client can inspect its account
+    state during session bootstrap; the blocked flag must be visible there."""
+    user = build_user(is_active=False)
+    dependency_overrides.set(get_authenticated_user, ProvideValue(user))
+
+    response = await async_client.get("/v1/users/me")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["is_active"] is False
+    assert payload["is_verified"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/src/user/test_user_routes.py
+++ b/tests/unit/src/user/test_user_routes.py
@@ -117,7 +117,7 @@ async def test_get_user_info_by_id_returns_404_when_user_is_missing(
 
     assert response.status_code == 404
     assert response.json() == {
-        "error": "Instance not found",
+        "code": "not_found",
         "message": "User not found",
     }
 
@@ -261,7 +261,7 @@ async def test_update_user_profile_returns_404_when_user_is_missing(
 
     assert response.status_code == 404
     assert response.json() == {
-        "error": "Instance not found",
+        "code": "not_found",
         "message": "User not found",
     }
 

--- a/tests/unit/src/user/test_user_routes.py
+++ b/tests/unit/src/user/test_user_routes.py
@@ -6,12 +6,12 @@ import pytest
 
 from src.core.database.session import get_session
 from src.core.errors.exceptions import (
-    AccessForbiddenException,
     InstanceNotFoundException,
     InstanceProcessingException,
 )
 from src.core.schemas import SuccessResponse
 from src.user.auth.dependencies import get_current_user
+from src.user.auth.errors import InvalidCredentialsError
 from src.user.auth.token_transport import TokenTransport, get_token_transport
 from src.user.dependencies import get_user_service
 from src.user.enums import UserRole
@@ -99,6 +99,32 @@ async def test_get_user_info_by_id(
     payload = response.json()
     assert payload["id"] == str(target_user.id)
     assert payload["username"] == target_user.username
+
+
+@pytest.mark.asyncio
+async def test_get_user_info_by_id_denies_without_view_users_permission(
+    async_client,
+    dependency_overrides: DependencyOverrides,
+    fake_session: FakeAsyncSession,
+) -> None:
+    # Exercises the real checker: a VIEWER role has no VIEW_USERS permission, so
+    # this proves require_permission's RBAC denial still runs and is now on the
+    # new error type - admission (blocked/unverified) is no longer its job.
+    viewer_user = build_user(role=UserRole.VIEWER)
+    target_user = build_user()
+    dependency_overrides.set(get_current_user, ProvideValue(viewer_user))
+    dependency_overrides.set(
+        get_user_service, ProvideValue(FakeUserService(target_user))
+    )
+    dependency_overrides.set(get_session, ProvideAsyncValue(fake_session))
+
+    response = await async_client.get(f"/v1/users/{target_user.id}")
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "code": "permission_denied",
+        "message": "Permission denied",
+    }
 
 
 @pytest.mark.asyncio
@@ -230,7 +256,7 @@ async def test_update_user_password_rejects_wrong_current_password(
         get_update_user_password_use_case,
         ProvideValue(
             FakeUpdatePasswordUseCase(
-                error=AccessForbiddenException("Current password is incorrect.")
+                error=InvalidCredentialsError("Current password is incorrect.")
             )
         ),
     )
@@ -240,7 +266,11 @@ async def test_update_user_password_rejects_wrong_current_password(
         json={"current_password": "WrongPass1!", "password": "StrongPass1!"},
     )
 
-    assert response.status_code == 403
+    assert response.status_code == 400
+    assert response.json() == {
+        "code": "invalid_credentials",
+        "message": "Current password is incorrect.",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/src/user/usecases/test_update_password_usecase.py
+++ b/tests/unit/src/user/usecases/test_update_password_usecase.py
@@ -6,11 +6,11 @@ import pytest
 
 from src.core.cache.memory_cache import InMemoryCache
 from src.core.errors.exceptions import (
-    AccessForbiddenException,
     InstanceNotFoundException,
     InstanceProcessingException,
 )
 from src.core.schemas import SuccessResponse
+from src.user.auth.errors import InvalidCredentialsError
 from src.user.auth.schemas import UserNewPassword
 from src.user.cache_keys import user_cache_keys
 from src.user.models import User
@@ -79,7 +79,7 @@ async def test_update_password_rejects_wrong_current_password(
 
     use_case = UpdateUserPasswordUseCase(uow=uow, redis_client=fake_redis, cache=cache)
 
-    with pytest.raises(AccessForbiddenException):
+    with pytest.raises(InvalidCredentialsError, match="Current password is incorrect."):
         await use_case.execute(
             data=change_password_data(current="WrongPass1!"),
             user_id=user.id,


### PR DESCRIPTION
One flat error body `{"code","message"}` across handlers, middleware fallbacks and the nginx error pages, driven by an `ErrorCode` enum and declarative exception attributes with a single generic handler (Starlette MRO dispatch). Account admission (active + verified) extracted into pure `src/user/policies.py` and wired through login, refresh and the permission checker; `get_current_user` now gates blocked/unverified accounts with honest 403 codes, the single opt-out is `GET /me`. Login keeps one `invalid_credentials` answer for every failure reason (anti-enumeration) and stays HTTP 400 by design. Distinct `token_expired`/`csrf_failed` codes. Dead exception types removed; `OperationalError` now answers 503; unique/FK violations no longer echo database values.

Testing: full suite green (765 tests) incl. new contract walk, policy, matrix, gate and framework-HTTPException tests.

Config/env: none.

Rollout: frontend error parsing must switch from `error` to `code`.