### PR TITLE
fix(auth): honest name validation and reset-request anti-enumeration

### DIFF
--- a/src/core/validations.py
+++ b/src/core/validations.py
@@ -12,17 +12,14 @@ PASSWORD_MAX_LENGTH = 128
 PHONE_NUMBER_MIN_LENGTH = 5
 
 # Name and personal identifiers
-# Validates a full name with alphanumeric characters only (no spaces)
-# Example: "JohnDoe123"
-FULL_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9]{2,30}$")
+# Latin letters; single spaces, hyphens or apostrophes between parts.
+# Length (2-30) is enforced by the schemas via Field, not here.
+# Example: "Anne-Marie", "O'Brien", "John Smith"
+FULL_NAME_PATTERN = re.compile(r"^[a-zA-Z]+(?:[ '\-][a-zA-Z]+)*$")
 
 # Validates a username with alphanumeric characters, underscore, dash, and dot
 # Example: "john.doe_2023"
 USERNAME_VALIDATOR = re.compile(r"^[a-zA-Z0-9_\-.]{4,60}$")
-
-# Validates a name with letters and spaces only
-# Example: "John Smith"
-NAME_WITH_SPACES = re.compile(r"^[a-zA-Z\s]{2,50}$")
 
 # Phone related
 # Validates a phone number in international E.164 format (starts with + followed by country code and digits)

--- a/src/user/auth/schemas.py
+++ b/src/user/auth/schemas.py
@@ -14,8 +14,8 @@ from src.core.validations import (
 
 
 class CreateUserModel(StrongPasswordValidationMixin, EmailNormalizationMixin, Base):
-    first_name: str
-    last_name: str
+    first_name: str = Field(min_length=2, max_length=30)
+    last_name: str = Field(min_length=2, max_length=30)
     email: EmailStr
     username: str
     phone_number: str = Field(min_length=PHONE_NUMBER_MIN_LENGTH)
@@ -25,14 +25,20 @@ class CreateUserModel(StrongPasswordValidationMixin, EmailNormalizationMixin, Ba
     @classmethod
     def validate_first_name(cls, value: str) -> str:
         if not FULL_NAME_PATTERN.match(value):
-            raise ValueError("First name must contain latin letters and spaces only")
+            raise ValueError(
+                "First name must contain latin letters, with single spaces, "
+                "hyphens or apostrophes between parts"
+            )
         return value
 
     @field_validator("last_name")
     @classmethod
     def validate_last_name(cls, value: str) -> str:
         if not FULL_NAME_PATTERN.match(value):
-            raise ValueError("Last name must contain latin letters and spaces only")
+            raise ValueError(
+                "Last name must contain latin letters, with single spaces, "
+                "hyphens or apostrophes between parts"
+            )
         return value
 
     @field_validator("phone_number")

--- a/src/user/auth/usecases/reset_password_request.py
+++ b/src/user/auth/usecases/reset_password_request.py
@@ -5,6 +5,7 @@ from fastapi import Depends
 from loggers import get_logger
 from src.core.database.session import get_unit_of_work
 from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
+from src.core.errors.exceptions import InstanceProcessingException
 from src.core.schemas import SuccessResponse
 from src.core.utils.security import build_email_throttle_key, mask_email
 from src.user.auth.schemas import SendResetPasswordRequestModel
@@ -28,8 +29,10 @@ class ResetPasswordRequestUseCase:
 
     Workflow:
     1) Retrieve user by email.
-    2) If user exists, store the password reset email delivery in the outbox
-       using the notifier with throttling.
+    2) Store the password reset email delivery in the outbox using the
+       notifier with throttling. If a reset email was already sent recently
+       and the throttle window has not elapsed, return success=True without
+       committing, to prevent email enumeration.
     3) Commit the transaction (the outbox publish hook fires after commit).
 
     Side effects:
@@ -37,10 +40,6 @@ class ResetPasswordRequestUseCase:
       after commit.
     - Sets/updates a throttle key in Redis; releases it if the transaction
       fails to commit.
-
-    Errors:
-    - InstanceProcessingException: if a reset email was already sent recently
-      and the throttle window has not elapsed.
 
     Returns:
     - SuccessResponse: success=True regardless of whether email was sent.
@@ -65,11 +64,19 @@ class ResetPasswordRequestUseCase:
                 return SuccessResponse(success=True)
 
             throttle_key = build_email_throttle_key("password-reset", user.email)
-            await self.notifier.send_password_reset_email(
-                uow=uow,
-                user=user,
-                throttle_key=throttle_key,
-            )
+            try:
+                await self.notifier.send_password_reset_email(
+                    uow=uow,
+                    user=user,
+                    throttle_key=throttle_key,
+                )
+            except InstanceProcessingException:
+                logger.debug(
+                    "[ResetPasswordRequest] Skip sending to email '%s' due to throttle",
+                    mask_email(data.email),
+                )
+                return SuccessResponse(success=True)
+
             try:
                 await uow.commit()
             except Exception:

--- a/src/user/schemas.py
+++ b/src/user/schemas.py
@@ -1,15 +1,26 @@
 from uuid import UUID
 
-from pydantic import EmailStr, Field
+from pydantic import EmailStr, Field, field_validator
 
 from src.core.schemas import Base
+from src.core.validations import FULL_NAME_PATTERN
 from src.user.enums import UserRole
 
 
 class UserProfileUpdateModel(Base):
-    first_name: str | None = Field(None, min_length=1, max_length=50)
-    last_name: str | None = Field(None, min_length=1, max_length=50)
+    first_name: str | None = Field(None, min_length=2, max_length=30)
+    last_name: str | None = Field(None, min_length=2, max_length=30)
     username: str | None = Field(None, min_length=3, max_length=50)
+
+    @field_validator("first_name", "last_name")
+    @classmethod
+    def validate_name(cls, value: str | None) -> str | None:
+        if value is not None and not FULL_NAME_PATTERN.match(value):
+            raise ValueError(
+                "Name must contain latin letters, with single spaces, "
+                "hyphens or apostrophes between parts"
+            )
+        return value
 
 
 class UserProfileViewModel(Base):

--- a/tests/unit/src/user/auth/test_auth_schemas.py
+++ b/tests/unit/src/user/auth/test_auth_schemas.py
@@ -1,7 +1,40 @@
 from pydantic import ValidationError
 import pytest
 
-from src.user.auth.schemas import UserNewPassword
+from src.user.auth.schemas import CreateUserModel, UserNewPassword
+from src.user.schemas import UserProfileUpdateModel
+
+VALID_USER_KWARGS = dict(
+    email="user@example.com",
+    username="john.doe",
+    phone_number="+12025550179",
+    password="Str0ng!Passw0rd",
+)
+
+
+@pytest.mark.parametrize("name", ["John", "Anne-Marie", "O'Brien", "John Smith"])
+def test_create_user_accepts_real_names(name: str) -> None:
+    model = CreateUserModel(first_name=name, last_name=name, **VALID_USER_KWARGS)
+    assert model.first_name == name
+
+
+@pytest.mark.parametrize(
+    "name", ["Ivan42", "-John", "John--Smith", "John  Smith", "J", "John "]
+)
+def test_create_user_rejects_malformed_names(name: str) -> None:
+    with pytest.raises(ValidationError):
+        CreateUserModel(first_name=name, last_name="Doe", **VALID_USER_KWARGS)
+
+
+@pytest.mark.parametrize("name", ["Anne-Marie", "O'Brien"])
+def test_profile_update_accepts_real_names(name: str) -> None:
+    assert UserProfileUpdateModel(first_name=name).first_name == name
+
+
+@pytest.mark.parametrize("name", ["Ivan42", "John--Smith"])
+def test_profile_update_rejects_malformed_names(name: str) -> None:
+    with pytest.raises(ValidationError):
+        UserProfileUpdateModel(first_name=name)
 
 
 def test_user_new_password_allows_printable_ascii_symbols_outside_old_whitelist() -> (

--- a/tests/unit/src/user/auth/usecases/test_auth_usecases_stage1.py
+++ b/tests/unit/src/user/auth/usecases/test_auth_usecases_stage1.py
@@ -375,6 +375,28 @@ async def test_reset_password_request_releases_throttle_when_commit_fails(
 
 
 @pytest.mark.asyncio
+async def test_reset_password_request_skips_if_throttled(
+    fake_session: FakeAsyncSession,
+) -> None:
+    user = build_user()
+    users_repo = FakeUsersRepository(user=user)
+    uow = build_uow(fake_session, users_repo)
+    notifier = FakeResetPasswordNotifier()
+    notifier.send_password_reset_email.side_effect = InstanceProcessingException(
+        "throttled"
+    )
+    use_case = ResetPasswordRequestUseCase(uow=uow, notifier=notifier)
+
+    data = SendResetPasswordRequestModel(email=user.email)
+    result = await use_case.execute(data=data)
+
+    assert result == SuccessResponse(success=True)
+    notifier.send_password_reset_email.assert_awaited_once()
+    assert notifier.send_password_reset_email.await_args.kwargs["uow"] is uow
+    uow.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_reset_password_request_user_not_found(
     fake_session: FakeAsyncSession,
 ) -> None:

--- a/tests/unit/src/user/test_user_routes.py
+++ b/tests/unit/src/user/test_user_routes.py
@@ -325,7 +325,7 @@ async def test_update_user_profile_returns_404_when_user_is_missing(
     "payload",
     [
         pytest.param({"first_name": ""}, id="first_name-below-min-length"),
-        pytest.param({"first_name": "x" * 51}, id="first_name-above-max-length"),
+        pytest.param({"first_name": "a" * 31}, id="first_name-above-max-length"),
         pytest.param({"username": "ab"}, id="username-below-min-length"),
         pytest.param({"username": "x" * 51}, id="username-above-max-length"),
         pytest.param({"nickname": "Grace"}, id="unknown-field-is-rejected"),


### PR DESCRIPTION
Two auth request-path fixes.

**Name validation.** `FULL_NAME_PATTERN` allowed digits and forbade spaces while the error message promised "latin letters and spaces". The pattern now accepts latin letters with single spaces, hyphens or apostrophes between parts; length (2-30) moved to `Field` bounds; messages match the rule. `UserProfileUpdateModel` previously skipped format validation entirely and now applies the same pattern, closing the register-vs-update inconsistency. Dead `NAME_WITH_SPACES` removed.

**Anti-enumeration.** A repeated password-reset request for an existing email surfaced the notifier throttle as HTTP 400 while unknown emails got 200 — two requests revealed account existence. The use case now swallows the throttle and returns `success=True`, mirroring `resend_verification`; the notifier-level raise stays test-pinned.

Testing: new schema and throttle tests; full suite 786 green, lint clean.
