### PR TITLE
feat(database): refuse repository commit=True inside an active UnitOfWork

### DIFF
--- a/src/core/database/repositories.py
+++ b/src/core/database/repositories.py
@@ -75,10 +75,24 @@ class BaseRepository(Generic[T]):
                     "searchable"
                 )
 
+    @staticmethod
+    def _ensure_commit_allowed(session: AsyncSession) -> None:
+        # A UoW owns its transaction: a direct commit under it would end the
+        # transaction while the UoW still believes it is open (rollback becomes
+        # impossible, uow.commit() would later "succeed" on nothing).
+        if session.info.get("uow_active"):
+            raise RuntimeError(
+                "commit=True inside an active UnitOfWork: the UoW owns the "
+                "transaction. Call the repository with commit=False and let "
+                "the UoW commit."
+            )
+
     async def create(
         self, session: AsyncSession, data: dict[str, Any], commit: bool = False
     ) -> T:
         """Create a new record using the provided session."""
+        if commit:
+            self._ensure_commit_allowed(session)
         try:
             instance = self.model(**data)
             session.add(instance)
@@ -236,6 +250,8 @@ class BaseRepository(Generic[T]):
         **filters: Any,
     ) -> T | None:
         """Update a record using the provided session."""
+        if commit:
+            self._ensure_commit_allowed(session)
         self._ensure_filters_present(filters)
         try:
             query = select(self.model).filter_by(**filters)
@@ -269,6 +285,8 @@ class BaseRepository(Generic[T]):
         self, session: AsyncSession, commit: bool = False, **filters: Any
     ) -> T | None:
         """Delete a record using the provided session."""
+        if commit:
+            self._ensure_commit_allowed(session)
         self._ensure_filters_present(filters)
         try:
             query = select(self.model).filter_by(**filters)
@@ -402,6 +420,8 @@ class SoftDeleteRepository(BaseRepository[T], Generic[T]):
         self, session: AsyncSession, commit: bool = False, **filters: Any
     ) -> T | None:
         """Soft delete a record, using the filters."""
+        if commit:
+            self._ensure_commit_allowed(session)
         filters.setdefault("is_deleted", False)
         try:
             query = select(self.model).filter_by(**filters)
@@ -434,6 +454,8 @@ class SoftDeleteRepository(BaseRepository[T], Generic[T]):
         commit: bool = False,
     ) -> int:
         """Soft delete multiple records matching the typed filter conditions."""
+        if commit:
+            self._ensure_commit_allowed(session)
         if not filters.has_conditions():
             raise ValueError("At least one filter condition must be provided")
         merged = FilterCondition(

--- a/src/core/database/uow/sqlalchemy.py
+++ b/src/core/database/uow/sqlalchemy.py
@@ -49,6 +49,7 @@ class SQLAlchemyUnitOfWork(UnitOfWork[R]):
         """
         await self._exit_stack.__aenter__()
         await self._exit_stack.enter_async_context(safe_begin(self._session))
+        self._session.info["uow_active"] = True
         return self
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
@@ -60,10 +61,12 @@ class SQLAlchemyUnitOfWork(UnitOfWork[R]):
             exc_val: Exception value if an exception was raised
             exc_tb: Exception traceback if an exception was raised
         """
-        if exc_type is not None and not self._is_completed:
-            await self.rollback()
-
-        await self._exit_stack.__aexit__(exc_type, exc_val, exc_tb)
+        try:
+            if exc_type is not None and not self._is_completed:
+                await self.rollback()
+            await self._exit_stack.__aexit__(exc_type, exc_val, exc_tb)
+        finally:
+            self._session.info.pop("uow_active", None)
 
     def _ensure_not_completed(self) -> None:
         if self._is_completed:

--- a/tests/fakes/db.py
+++ b/tests/fakes/db.py
@@ -35,6 +35,9 @@ class FakeAsyncSession:
         self.execute = AsyncMock()
         self.add = MagicMock()
         self.delete = AsyncMock()
+        # Mirrors real `AsyncSession.info`: a plain dict the UoW uses to mark
+        # itself active for the repository commit guard.
+        self.info: dict[str, Any] = {}
 
     def in_transaction(self) -> bool:
         return self._in_transaction

--- a/tests/unit/src/core/database/test_database_repositories.py
+++ b/tests/unit/src/core/database/test_database_repositories.py
@@ -116,6 +116,8 @@ class RepositorySession:
         self.delete = AsyncMock()
         self.execute = AsyncMock()
         self.scalar = AsyncMock()
+        # Mirrors real `AsyncSession.info`, consulted by the commit guard.
+        self.info: dict[str, Any] = {}
 
 
 FIXED_NOW = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)

--- a/tests/unit/src/core/database/test_uow_commit_guard.py
+++ b/tests/unit/src/core/database/test_uow_commit_guard.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.core.database.uow.application import ApplicationUnitOfWork
+from src.core.utils.security import hash_password
+from src.user.enums import UserRole
+from src.user.repositories import UserRepository
+from tests.fakes.db import FakeAsyncSession
+
+
+def _valid_user_data(**overrides: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "first_name": "Test",
+        "last_name": "User",
+        "email": "user@example.com",
+        "username": "user",
+        "phone_number": "+10000000000",
+        "password_hash": hash_password("password"),
+        "role": UserRole.VIEWER,
+        "is_verified": True,
+        "is_active": True,
+    }
+    data.update(overrides)
+    return data
+
+
+@pytest.fixture
+def session() -> FakeAsyncSession:
+    return FakeAsyncSession()
+
+
+@pytest.fixture
+def user_repository() -> UserRepository:
+    return UserRepository()
+
+
+async def test_standalone_commit_allowed_even_after_autobegin(
+    session: FakeAsyncSession, user_repository: UserRepository
+) -> None:
+    # a prior read opens a transaction via autobegin; guard must not trip
+    session.execute.return_value = MagicMock()
+    await user_repository.get_list(session)
+    created = await user_repository.create(
+        session, data=_valid_user_data(), commit=True
+    )
+    assert created is not None
+
+
+async def test_commit_true_inside_uow_raises(
+    session: FakeAsyncSession, user_repository: UserRepository
+) -> None:
+    uow = ApplicationUnitOfWork(session)
+    async with uow:
+        with pytest.raises(RuntimeError, match="inside an active UnitOfWork"):
+            await user_repository.create(session, data=_valid_user_data(), commit=True)
+        # the UoW transaction survived the refusal
+        await uow.commit()
+
+
+async def test_commit_false_inside_uow_is_legal(
+    session: FakeAsyncSession, user_repository: UserRepository
+) -> None:
+    async with ApplicationUnitOfWork(session) as uow:
+        await user_repository.create(uow.session, data=_valid_user_data(), commit=False)
+        await uow.commit()
+
+
+async def test_marker_cleared_after_uow_exit(session: FakeAsyncSession) -> None:
+    async with ApplicationUnitOfWork(session):
+        assert session.info.get("uow_active") is True
+    assert session.info.get("uow_active") is None
+
+
+async def test_marker_cleared_when_uow_body_raises(session: FakeAsyncSession) -> None:
+    with pytest.raises(ValueError):
+        async with ApplicationUnitOfWork(session):
+            raise ValueError("boom")
+    assert session.info.get("uow_active") is None


### PR DESCRIPTION
`BaseService` write methods pass `commit=True`, and `BaseRepository` then calls `session.commit()` directly. Doing that inside `async with uow` committed the outer transaction early: the UoW's `_is_completed` stayed `False`, its later `commit()` "succeeded" on nothing, and rollback became impossible. The trap was documented in words only, never enforced.

The UnitOfWork now marks its session (`session.info["uow_active"]`) for the duration of the context, and every commit-capable repository write (`create`, `update`, `delete`, soft-delete `delete`, `batch_soft_delete`) refuses `commit=True` under an active UoW with a clear `RuntimeError` raised before touching the session. `session.in_transaction()` is deliberately not consulted: SQLAlchemy autobegin would false-positive on legitimate standalone service calls.

Standalone writes — including after a prior read on the same session — keep working, proven by tests; the marker clears on both clean and exceptional exit. Full suite 776 green, lint clean.
