### PR TITLE
refactor(security): drop passlib, hash passwords off the event loop

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,7 @@ repos:
           - redis==8.1.0
           - pytest==9.1.1
           - alembic==1.19.1
+          - argon2-cffi==25.1.0
           - types-passlib==1.7.7.20260211
           - types-PyYAML==6.0.12.20260724
           - types-requests==2.33.0.20260712

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,6 @@ repos:
           - pytest==9.1.1
           - alembic==1.19.1
           - argon2-cffi==25.1.0
-          - types-passlib==1.7.7.20260211
           - types-PyYAML==6.0.12.20260724
           - types-requests==2.33.0.20260712
           - types-ujson==5.10.0.20250822

--- a/docs/readme/security.md
+++ b/docs/readme/security.md
@@ -34,9 +34,9 @@ If a consumed token is presented again, **all user sessions are invalidated imme
 
 `src/core/utils/security.py`
 
-- Algorithm: **Argon2** (OWASP-recommended, memory-hard).
+- Algorithm: **Argon2** (OWASP-recommended, memory-hard), via `argon2-cffi` directly.
 - Parameters: 64 MB memory, 3 iterations, 2 threads.
-- Verification runs via `asyncio.to_thread()` to avoid blocking the event loop.
+- Hashing and verification both run via `asyncio.to_thread()` to avoid blocking the event loop.
 - `needs_password_rehash()` detects outdated hash parameters; `_rehash_password_if_needed()` in the login flow transparently upgrades hashes on successful authentication.
 
 **Why it matters:** Argon2's memory-hardness makes GPU/ASIC brute-force impractical. Auto-rehash ensures that strengthening parameters takes effect without requiring users to reset passwords.
@@ -46,7 +46,7 @@ If a consumed token is presented again, **all user sessions are invalidated imme
 `src/user/auth/usecases/login.py`, `reset_password_request.py`, `resend_verification.py`
 
 All authentication endpoints return **identical responses** regardless of whether a user exists:
-- Login: verifies the password against a pre-computed dummy hash (`INVALID_CREDENTIALS_PASSWORD_HASH`) when the user is not found, producing constant execution time.
+- Login: verifies the password against a pre-computed dummy hash (`DUMMY_PASSWORD_HASH`) when the user is not found, producing constant execution time.
 - Password reset and resend verification: return `success=True` even if the email is not registered.
 
 **Why it matters:** Timing and response differences let attackers enumerate valid accounts. Dummy-hash verification eliminates the timing side-channel; uniform responses eliminate the content side-channel.

--- a/infra/requirements/base.in
+++ b/infra/requirements/base.in
@@ -3,7 +3,7 @@ aiohttp>=3.14.3  # security: CVE-2026-34993/47265/50269/54273-54280, PYSEC-2026-
 aiosmtplib>=5.1.1  # security: PYSEC-2026-2338
 alembic
 alembic-postgresql-enum
-argon2-cffi
+argon2-cffi  # direct argon2 backend for password hashing (passlib removed as unmaintained)
 asyncpg
 click>=8.3.3  # security: PYSEC-2026-2132
 email-validator
@@ -11,7 +11,6 @@ fastapi
 gunicorn
 jinja2
 mako>=1.4.1
-passlib
 pydantic
 pydantic-settings
 pyjwt

--- a/infra/requirements/base.txt
+++ b/infra/requirements/base.txt
@@ -107,8 +107,6 @@ packaging==26.3
     # via
     #   gunicorn
     #   taskiq
-passlib==1.7.4
-    # via -r base.in
 propcache==0.5.2
     # via
     #   aiohttp

--- a/infra/requirements/dev.in
+++ b/infra/requirements/dev.in
@@ -14,7 +14,6 @@ pytest-cov
 taskiq[reload]
 
 # Type stubs
-types-passlib
 types-PyYAML
 types-requests
 types-ujson

--- a/infra/requirements/dev.txt
+++ b/infra/requirements/dev.txt
@@ -153,8 +153,6 @@ packaging==26.3
     #   pytest
     #   taskiq
     #   wheel
-passlib==1.7.4
-    # via -r base.in
 pathspec==1.1.1
     # via
     #   black
@@ -254,8 +252,6 @@ truststore==0.10.4
     # via
     #   httpcore2
     #   httpx2
-types-passlib==1.7.7.20260211
-    # via -r dev.in
 types-pyyaml==6.0.12.20260724
     # via -r dev.in
 types-requests==2.33.0.20260712

--- a/infra/requirements/prod.txt
+++ b/infra/requirements/prod.txt
@@ -107,8 +107,6 @@ packaging==26.3
     # via
     #   gunicorn
     #   taskiq
-passlib==1.7.4
-    # via -r base.in
 propcache==0.5.2
     # via
     #   aiohttp

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,3 @@
 [pytest]
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
-filterwarnings =
-    ignore:'crypt' is deprecated.*:DeprecationWarning:passlib.*
-    ignore:Accessing argon2.__version__ is deprecated.*:DeprecationWarning:passlib.*

--- a/src/core/utils/security.py
+++ b/src/core/utils/security.py
@@ -2,75 +2,48 @@ import asyncio
 import hashlib
 import secrets
 
-from passlib.context import CryptContext
+from argon2 import PasswordHasher
+from argon2.exceptions import InvalidHashError, VerificationError
 from pydantic import EmailStr
 
 from loggers import get_logger
 
 logger = get_logger(__name__)
 
-pwd_context = CryptContext(
-    schemes=["argon2"],
-    deprecated="auto",
-    argon2__memory_cost=65536,  # 64 MB
-    argon2__time_cost=3,
-    argon2__parallelism=2,
+password_hasher = PasswordHasher(
+    memory_cost=65536,  # 64 MB
+    time_cost=3,
+    parallelism=2,
 )
 
+# Computed once at import. Login verifies against it when the user does not
+# exist, so failure timing matches a real password check; it must be a real
+# hash produced with the current parameters.
+DUMMY_PASSWORD_HASH: str = password_hasher.hash("dummy-password")
 
-def hash_password(password: str) -> str:
-    """
-    Hashes a given plaintext password using a secure hashing algorithm.
 
-    This function uses a password hashing context to hash the input password securely.
-
-    Args:
-        password: A plaintext password string to be hashed.
-
-    Returns:
-        The securely hashed password as a string.
-    """
-    return pwd_context.hash(password)
+async def hash_password(password: str) -> str:
+    """Hash a plaintext password with Argon2 off the event loop."""
+    return await asyncio.to_thread(password_hasher.hash, password)
 
 
 def is_password_hash(value: str) -> bool:
-    """
-    Check whether the given value looks like a password hash.
-    """
-    return pwd_context.identify(value) is not None
+    """Check whether the given value looks like an Argon2 password hash."""
+    return value.startswith("$argon2")
 
 
 def needs_password_rehash(hashed_password: str) -> bool:
-    """
-    Determines if a hashed password needs to be rehashed to maintain security.
-
-    This function evaluates whether a given hashed password requires rehashing based
-    on the current settings of the password hashing context. Rehashing is necessary
-    if the algorithm, iteration count, or salt length has changed since the password
-    was first hashed.
-
-    Args:
-        hashed_password: The hashed password to be evaluated as a string.
-
-    Returns:
-        bool: True if the hashed password needs to be rehashed, False otherwise.
-    """
-    return pwd_context.needs_update(hashed_password)
+    """True when the hash was made with outdated parameters."""
+    return password_hasher.check_needs_rehash(hashed_password)
 
 
 async def verify_password(plain_password: str, hashed_password: str) -> bool:
-    """
-    Verifies that a text password matches its hashed counterpart.
-
-    :param plain_password: The text password provided by the user.
-    :param hashed_password: The stored hashed password from the database.
-    :return: True if the passwords match, False otherwise.
-    """
+    """Verify a password against its hash off the event loop."""
     try:
         return await asyncio.to_thread(
-            pwd_context.verify, plain_password, hashed_password
+            password_hasher.verify, hashed_password, plain_password
         )
-    except ValueError:
+    except (VerificationError, InvalidHashError, ValueError):
         return False
 
 

--- a/src/core/utils/security.py
+++ b/src/core/utils/security.py
@@ -1,8 +1,9 @@
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import hashlib
 import secrets
 
-from argon2 import PasswordHasher
+from argon2 import PasswordHasher, extract_parameters
 from argon2.exceptions import InvalidHashError, VerificationError
 from pydantic import EmailStr
 
@@ -16,6 +17,12 @@ password_hasher = PasswordHasher(
     parallelism=2,
 )
 
+# Every concurrent Argon2 call holds memory_cost (64 MB) for its duration.
+# A dedicated bounded executor caps hashing memory at max_workers * 64 MB
+# no matter how many requests arrive at once; the default executor would
+# allow up to min(32, cpu + 4) simultaneous hashes.
+_password_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="argon2")
+
 # Computed once at import. Login verifies against it when the user does not
 # exist, so failure timing matches a real password check; it must be a real
 # hash produced with the current parameters.
@@ -24,12 +31,18 @@ DUMMY_PASSWORD_HASH: str = password_hasher.hash("dummy-password")
 
 async def hash_password(password: str) -> str:
     """Hash a plaintext password with Argon2 off the event loop."""
-    return await asyncio.to_thread(password_hasher.hash, password)
+    return await asyncio.get_running_loop().run_in_executor(
+        _password_executor, password_hasher.hash, password
+    )
 
 
 def is_password_hash(value: str) -> bool:
-    """Check whether the given value looks like an Argon2 password hash."""
-    return value.startswith("$argon2")
+    """Check whether the given value is a structurally valid Argon2 hash."""
+    try:
+        extract_parameters(value)
+    except InvalidHashError:
+        return False
+    return True
 
 
 def needs_password_rehash(hashed_password: str) -> bool:
@@ -40,8 +53,8 @@ def needs_password_rehash(hashed_password: str) -> bool:
 async def verify_password(plain_password: str, hashed_password: str) -> bool:
     """Verify a password against its hash off the event loop."""
     try:
-        return await asyncio.to_thread(
-            password_hasher.verify, hashed_password, plain_password
+        return await asyncio.get_running_loop().run_in_executor(
+            _password_executor, password_hasher.verify, hashed_password, plain_password
         )
     except (VerificationError, InvalidHashError, ValueError):
         return False

--- a/src/user/auth/usecases/login.py
+++ b/src/user/auth/usecases/login.py
@@ -12,6 +12,7 @@ from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
 from src.core.redis.dependencies import get_redis_client
 from src.core.schemas import TokenModel
 from src.core.utils.security import (
+    DUMMY_PASSWORD_HASH,
     hash_password,
     mask_email,
     needs_password_rehash,
@@ -28,7 +29,6 @@ from src.user.policies import (
     ensure_can_authenticate,
 )
 
-INVALID_CREDENTIALS_PASSWORD_HASH = hash_password("dummy-password")
 logger = get_logger(__name__)
 
 
@@ -90,7 +90,7 @@ class LoginUserUseCase:
                     "[LoginUser] User with email '%s' not found.",
                     mask_email(data.email),
                 )
-                await verify_password(data.password, INVALID_CREDENTIALS_PASSWORD_HASH)
+                await verify_password(data.password, DUMMY_PASSWORD_HASH)
                 raise InvalidCredentialsError(INVALID_CREDENTIALS_MESSAGE)
 
             correct_password = await verify_password(data.password, user.password_hash)
@@ -134,9 +134,10 @@ class LoginUserUseCase:
     ) -> None:
         if not needs_password_rehash(user.password_hash):
             return
+        new_hash = await hash_password(raw_password)
         await uow.users.update(
             uow.session,
-            {"password_hash": hash_password(raw_password)},
+            {"password_hash": new_hash},
             id=user.id,
         )
 

--- a/src/user/auth/usecases/register.py
+++ b/src/user/auth/usecases/register.py
@@ -57,7 +57,7 @@ class RegisterUseCase:
         async with self.uow as uow:
             user_data = data.model_dump()
             raw_password = user_data.pop("password")
-            user_data["password_hash"] = hash_password(raw_password)
+            user_data["password_hash"] = await hash_password(raw_password)
             user = await uow.users.create(
                 session=uow.session,
                 data=user_data,

--- a/src/user/auth/usecases/reset_password_confirm.py
+++ b/src/user/auth/usecases/reset_password_confirm.py
@@ -98,9 +98,10 @@ class ResetPasswordConfirmUseCase:
                         redis_client=self.redis_client,
                     )
 
+                    new_password_hash = await hash_password(data.password)
                     user = await uow.users.update(
                         uow.session,
-                        {"password_hash": hash_password(data.password)},
+                        {"password_hash": new_password_hash},
                         email=normalized_email,
                     )
                     if not user:

--- a/src/user/usecases/update_password.py
+++ b/src/user/usecases/update_password.py
@@ -95,7 +95,8 @@ class UpdateUserPasswordUseCase:
                     "New password must differ from the current one."
                 )
 
-            update_data = {"password_hash": hash_password(data.password)}
+            new_password_hash = await hash_password(data.password)
+            update_data = {"password_hash": new_password_hash}
             updated_user = await uow.users.update(uow.session, update_data, id=user_id)
             if not updated_user:
                 raise InstanceNotFoundException("User not found.")

--- a/tests/factories/user_factory.py
+++ b/tests/factories/user_factory.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from uuid import UUID, uuid4
 
-from src.core.utils.security import hash_password
+from src.core.utils.security import password_hasher
 from src.user.enums import UserRole
 from src.user.models import User
 
@@ -27,7 +27,7 @@ def build_user(
         email=email,
         username=username,
         phone_number=phone_number,
-        password_hash=hash_password(password),
+        password_hash=password_hasher.hash(password),
         role=role,
         is_verified=is_verified,
         is_active=is_active,

--- a/tests/unit/src/core/database/test_uow_commit_guard.py
+++ b/tests/unit/src/core/database/test_uow_commit_guard.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from src.core.database.uow.application import ApplicationUnitOfWork
-from src.core.utils.security import hash_password
+from src.core.utils.security import password_hasher
 from src.user.enums import UserRole
 from src.user.repositories import UserRepository
 from tests.fakes.db import FakeAsyncSession
@@ -19,7 +19,7 @@ def _valid_user_data(**overrides: Any) -> dict[str, Any]:
         "email": "user@example.com",
         "username": "user",
         "phone_number": "+10000000000",
-        "password_hash": hash_password("password"),
+        "password_hash": password_hasher.hash("password"),
         "role": UserRole.VIEWER,
         "is_verified": True,
         "is_active": True,

--- a/tests/unit/src/core/utils/test_security_utils.py
+++ b/tests/unit/src/core/utils/test_security_utils.py
@@ -24,6 +24,7 @@ async def test_verify_garbage_hash_returns_false() -> None:
 async def test_is_password_hash() -> None:
     assert is_password_hash(await hash_password("S3cret!pass")) is True
     assert is_password_hash("plaintext") is False
+    assert is_password_hash("$argon2garbage") is False
 
 
 async def test_needs_rehash_on_weaker_parameters() -> None:

--- a/tests/unit/src/core/utils/test_security_utils.py
+++ b/tests/unit/src/core/utils/test_security_utils.py
@@ -1,20 +1,41 @@
 import pytest
 
 from src.core.utils import security
+from src.core.utils.security import (
+    DUMMY_PASSWORD_HASH,
+    hash_password,
+    is_password_hash,
+    needs_password_rehash,
+    verify_password,
+)
 
 
-@pytest.mark.asyncio
-async def test_hash_and_verify_password_success() -> None:
-    hashed = security.hash_password("strong-pass")
+async def test_hash_and_verify_roundtrip() -> None:
+    hashed = await hash_password("S3cret!pass")
+    assert hashed.startswith("$argon2")
+    assert await verify_password("S3cret!pass", hashed) is True
+    assert await verify_password("wrong", hashed) is False
 
-    assert await security.verify_password("strong-pass", hashed) is True
+
+async def test_verify_garbage_hash_returns_false() -> None:
+    assert await verify_password("whatever", "not-a-hash") is False
 
 
-@pytest.mark.asyncio
-async def test_verify_password_fail() -> None:
-    hashed = security.hash_password("original")
+async def test_is_password_hash() -> None:
+    assert is_password_hash(await hash_password("S3cret!pass")) is True
+    assert is_password_hash("plaintext") is False
 
-    assert await security.verify_password("other", hashed) is False
+
+async def test_needs_rehash_on_weaker_parameters() -> None:
+    from argon2 import PasswordHasher
+
+    weak = PasswordHasher(memory_cost=8, time_cost=1, parallelism=1).hash("x")
+    assert needs_password_rehash(weak) is True
+    assert needs_password_rehash(await hash_password("x")) is False
+
+
+def test_dummy_password_hash_is_real_argon2() -> None:
+    assert DUMMY_PASSWORD_HASH.startswith("$argon2")
 
 
 def test_mask_email_valid_and_invalid() -> None:
@@ -35,27 +56,6 @@ def test_generate_otp_range(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_generate_otp_invalid_length() -> None:
     with pytest.raises(ValueError, match="OTP length must be greater than 0, given 0."):
         security.generate_otp(0)
-
-
-def test_is_password_hash_recognizes_hash() -> None:
-    hashed = security.hash_password("strong-pass")
-
-    assert security.is_password_hash(hashed) is True
-    assert security.is_password_hash("plain-password") is False
-
-
-def test_needs_password_rehash_false_for_fresh_hash() -> None:
-    hashed = security.hash_password("strong-pass")
-
-    assert security.needs_password_rehash(hashed) is False
-
-
-def test_needs_password_rehash_true_when_context_requires(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(security.pwd_context, "needs_update", lambda _: True)
-
-    assert security.needs_password_rehash("any-hash") is True
 
 
 def test_build_email_throttle_key_and_normalize() -> None:

--- a/tests/unit/src/user/auth/usecases/test_login_usecase_rehash.py
+++ b/tests/unit/src/user/auth/usecases/test_login_usecase_rehash.py
@@ -4,11 +4,11 @@ import pytest
 
 from src.core.cache.memory_cache import InMemoryCache
 from src.core.errors.exceptions import InstanceProcessingException
+from src.core.utils.security import DUMMY_PASSWORD_HASH
 from src.user.auth.schemas import LoginUserModel
 import src.user.auth.usecases.login as login_usecase
 from src.user.auth.usecases.login import (
     INVALID_CREDENTIALS_MESSAGE,
-    INVALID_CREDENTIALS_PASSWORD_HASH,
     LoginUserUseCase,
 )
 from src.user.cache_keys import user_cache_keys
@@ -48,7 +48,7 @@ async def test_login_rehashes_password_when_needed(
     uow = build_uow(user, fake_session)
 
     needs_rehash_mock = Mock(return_value=True)
-    hash_mock = Mock(return_value="new-hash")
+    hash_mock = AsyncMock(return_value="new-hash")
     verify_mock = AsyncMock(return_value=True)
     access_mock = AsyncMock(return_value="access")
     refresh_mock = AsyncMock(return_value="refresh")
@@ -70,7 +70,7 @@ async def test_login_rehashes_password_when_needed(
     assert result.refresh_token == "refresh"
     needs_rehash_mock.assert_called_once_with(user.password_hash)
     verify_mock.assert_awaited_once_with("plain-pass", user.password_hash)
-    hash_mock.assert_called_once_with("plain-pass")
+    hash_mock.assert_awaited_once_with("plain-pass")
     uow.users.update.assert_awaited_once_with(
         uow.session,
         {"password_hash": "new-hash"},
@@ -140,9 +140,7 @@ async def test_login_returns_unified_error_for_missing_user_and_uses_dummy_hash(
             LoginUserModel(email="missing@example.com", password="plain-pass")
         )
 
-    verify_mock.assert_awaited_once_with(
-        "plain-pass", INVALID_CREDENTIALS_PASSWORD_HASH
-    )
+    verify_mock.assert_awaited_once_with("plain-pass", DUMMY_PASSWORD_HASH)
     uow.users.update.assert_not_awaited()
     uow.flush.assert_not_awaited()
     uow.commit.assert_not_awaited()


### PR DESCRIPTION
Password hashing moves off passlib (unmaintained since 2020) onto argon2-cffi directly — it was already the installed backend. Parameters are unchanged (memory_cost=65536, time_cost=3, parallelism=2), so existing hashes keep verifying; ones minted with old defaults fall into the established rehash-on-login path.

hash_password and verify_password become async and run on a dedicated ThreadPoolExecutor (max_workers=4): Argon2 holds 64 MB per concurrent call, so the bound caps hashing memory under request bursts instead of letting the default executor run up to min(32, cpu+4) hashes at once. All call sites await them. The import-time timing-equalizer hash moves into security.py as DUMMY_PASSWORD_HASH; login imports it instead of minting its own.

is_password_hash validates structure via argon2.extract_parameters (a bare $argon2 prefix no longer passes); needs_password_rehash uses check_needs_rehash. passlib/types-passlib removed from requirements, pre-commit mypy deps and pytest filterwarnings; lockfiles regenerated via make req-compile.

Testing: real-behavior hash/verify/rehash tests; full suite 791 green, lint clean.