### PR TITLE
docs(security): sync security.md with wave-6 state; verify checks token mode

### DIFF
--- a/docs/readme/security.md
+++ b/docs/readme/security.md
@@ -10,7 +10,6 @@ Overview of security mechanisms implemented in the template and the rationale be
 - `JWT_USER_SECRET_KEY` — access and refresh tokens.
 - `JWT_VERIFY_SECRET_KEY` — email verification tokens.
 - `JWT_RESET_PASSWORD_SECRET_KEY` — password reset tokens.
-- `JWT_ADMIN_SECRET_KEY` — reserved for admin tokens.
 
 Key compromise is isolated: leaking the reset-password key does not allow forging access tokens. Each token carries a unique JTI (JWT ID) tracked in Redis, enabling per-token revocation.
 
@@ -36,7 +35,7 @@ If a consumed token is presented again, **all user sessions are invalidated imme
 
 - Algorithm: **Argon2** (OWASP-recommended, memory-hard), via `argon2-cffi` directly.
 - Parameters: 64 MB memory, 3 iterations, 2 threads.
-- Hashing and verification both run via `asyncio.to_thread()` to avoid blocking the event loop.
+- Hashing and verification run off the event loop on a dedicated bounded executor (4 workers), capping concurrent Argon2 memory under request bursts.
 - `needs_password_rehash()` detects outdated hash parameters; `_rehash_password_if_needed()` in the login flow transparently upgrades hashes on successful authentication.
 
 **Why it matters:** Argon2's memory-hardness makes GPU/ASIC brute-force impractical. Auto-rehash ensures that strengthening parameters takes effect without requiring users to reset passwords.
@@ -108,7 +107,7 @@ Three-tier model:
 - All Pydantic schemas inherit from `Base` with `extra="forbid"` — unknown fields are rejected, not silently ignored.
 - Strong password regex: lowercase + uppercase + digit + special character, 8-128 chars, printable ASCII only.
 - Email normalization (`strip().lower()`) runs before validation via `EmailNormalizationMixin`.
-- Field-specific regex patterns for names, usernames, phone numbers, slugs, social handles.
+- Field-specific regex patterns for names, usernames and E.164 phone numbers.
 
 **Why it matters:** `extra="forbid"` prevents mass assignment attacks (injecting fields like `is_admin=True`). Strict regex patterns reject malformed input before it reaches business logic.
 

--- a/src/main/config.py
+++ b/src/main/config.py
@@ -240,6 +240,8 @@ class AppConfig(BaseModel):
     DEBUG: bool = False
     TESTING: bool = False
 
+    # Read by loggers/ straight from os.environ, never through this field; it
+    # stays here so startup and check_env keep requiring the key in .env.
     LOG_LEVEL: str
 
     CORS_ALLOWED_ORIGINS: list[str] = Field([])

--- a/src/user/auth/usecases/verify_email.py
+++ b/src/user/auth/usecases/verify_email.py
@@ -73,6 +73,7 @@ class VerifyEmailUseCase:
                     secret=config.jwt.JWT_VERIFY_SECRET_KEY,
                     purpose="verification",
                     redis_client=self.redis_client,
+                    expected_mode="verification_token",
                 )
 
                 user = await uow.users.get_single(uow.session, email=normalized_email)


### PR DESCRIPTION
Follow-up sweep after the wave-6 refactor: security.md dropped the deleted JWT_ADMIN_SECRET_KEY entry, describes the bounded Argon2 executor (4 workers) instead of asyncio.to_thread, and lists only the validators that still exist (names, usernames, E.164 phones).

verify_email now passes expected_mode="verification_token" to decode_one_time_token, making the mode check symmetric with the reset flow — not exploitable before (different secrets per purpose), but the omission read as an oversight after both flows moved onto one helper.

LOG_LEVEL in AppConfig carries a comment stating why it stays although loggers read os.environ directly: it keeps startup and check_env requiring the key in .env.

Testing: full suite 794 passed, make lint clean.