### PR TITLE
refactor: keep DB sessions out of routers

### DIFF
--- a/docs/readme/architecture.md
+++ b/docs/readme/architecture.md
@@ -46,6 +46,11 @@ Benefits:
 **External systems (S3, Email, Queues, HTTP clients)**
 - Always at the UseCase level or in infra adapters used by a UseCase.
 
+### Routers Never Receive a DB Session
+Routers only inject the Service or UseCase they call; the session itself stops one layer earlier. No exceptions — the system probes get theirs the same way, through `get_readiness_service`, not through a session dependency on the route.
+- `BaseService.__init__(repository, session, response_schema=None)` takes the session as a constructor argument; the DI provider that builds the service (e.g. `get_user_service`, `get_readiness_service`) resolves it via `Depends(get_session)` and passes it in. Every CRUD method then forwards `self.session` to the repository — no method still accepts a `session` argument.
+- Anti-pattern: injecting `AsyncSession` into a router, or passing a session from a router into a service method.
+
 ### Repository Access
 - All DB work goes through repositories; no direct SQL in usecases/services/routers.
 - Prefer base repository methods (e.g., `get_single`) before adding custom queries; if the same filters/settings are reused 2–3 times or more, extract them into a custom repository method.

--- a/src/core/services.py
+++ b/src/core/services.py
@@ -30,6 +30,9 @@ class BaseService(Generic[ModelType, CreateSchema, RepositoryType, ResponseSchem
     coordination, or multi-step workflows. Write methods (create/update/delete) commit automatically,
     so changes are persisted immediately.
 
+    The session is constructor-injected by the DI provider that builds the service (never passed
+    in from a router or a call site), and every CRUD method forwards it to the repository as-is.
+
     For any non-trivial flows—transactional orchestration across multiple repositories, conditional
     workflows, side effects (e.g., sending emails, cache updates, external API calls), or retries—
     prefer the Unit of Work (UoW) pattern and dedicated use cases.
@@ -38,36 +41,40 @@ class BaseService(Generic[ModelType, CreateSchema, RepositoryType, ResponseSchem
     def __init__(
         self,
         repository: RepositoryType,
+        session: AsyncSession,
         response_schema: type[ResponseSchema] | None = None,
     ):
         self.repository = repository
+        self.session = session
         self._response_schema = response_schema
 
     async def create(
         self,
-        session: AsyncSession,
         data: CreateSchema,
     ) -> ModelType:
         """Create a new record."""
         result = await self.repository.create(
-            session=session, data=data.model_dump(), commit=True
+            session=self.session, data=data.model_dump(), commit=True
         )
         return cast(ModelType, result)
 
     async def get_single(
         self,
-        session: AsyncSession,
         eager: list[Load] | None = None,
         **filters: Any,
     ) -> ModelType | None:
         """Retrieve a single record matching the filters."""
-        return await self.repository.get_single(session=session, eager=eager, **filters)
+        return await self.repository.get_single(
+            session=self.session, eager=eager, **filters
+        )
 
     async def get_single_or_404(
-        self, session: AsyncSession, eager: list[Load] | None = None, **filters: Any
+        self, eager: list[Load] | None = None, **filters: Any
     ) -> ModelType:
         """Retrieve a single record matching the filters or raise a 404 error."""
-        obj = await self.repository.get_single(session=session, eager=eager, **filters)
+        obj = await self.repository.get_single(
+            session=self.session, eager=eager, **filters
+        )
         if obj is None:
             raise InstanceNotFoundException(
                 f"{self.repository.model.__name__} not found"
@@ -76,16 +83,16 @@ class BaseService(Generic[ModelType, CreateSchema, RepositoryType, ResponseSchem
 
     async def get_list(
         self,
-        session: AsyncSession,
         eager: list[Load] | None = None,
         **filters: Any,
     ) -> list[ModelType]:
         """Retrieve a list of records matching the filters."""
-        return await self.repository.get_list(session=session, eager=eager, **filters)
+        return await self.repository.get_list(
+            session=self.session, eager=eager, **filters
+        )
 
     async def get_paginated_list(
         self,
-        session: AsyncSession,
         pagination: PaginationParams,
         eager: list[Load] | None = None,
         query: ListQuery | None = None,
@@ -93,7 +100,7 @@ class BaseService(Generic[ModelType, CreateSchema, RepositoryType, ResponseSchem
     ) -> PaginatedResponse[ResponseSchema]:
         """Retrieve a paginated list of records matching the filters."""
         items, total = await self.repository.get_paginated_list(
-            session=session,
+            session=self.session,
             page=pagination.page,
             size=pagination.size,
             eager=eager,
@@ -113,18 +120,19 @@ class BaseService(Generic[ModelType, CreateSchema, RepositoryType, ResponseSchem
 
     async def update(
         self,
-        session: AsyncSession,
         data: PydanticBase,
         **filters: Any,
     ) -> ModelType | None:
         """Update a record matching the filters."""
         return await self.repository.update(
-            session=session,
+            session=self.session,
             data=data.model_dump(exclude_unset=True),
             **filters,
             commit=True,
         )
 
-    async def delete(self, session: AsyncSession, **filters: Any) -> ModelType | None:
+    async def delete(self, **filters: Any) -> ModelType | None:
         """Delete a record matching the filters."""
-        return await self.repository.delete(session=session, **filters, commit=True)
+        return await self.repository.delete(
+            session=self.session, **filters, commit=True
+        )

--- a/src/system/dependencies.py
+++ b/src/system/dependencies.py
@@ -2,7 +2,9 @@ from typing import Annotated
 
 from fastapi import Depends
 from redis.asyncio import Redis
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.core.database.session import get_session
 from src.core.redis.dependencies import get_redis_client
 from src.system.repositories import SystemRepository
 from src.system.services import HealthService, ReadinessService
@@ -14,8 +16,9 @@ def get_system_repository() -> SystemRepository:
 
 async def get_readiness_service(
     repository: Annotated[SystemRepository, Depends(get_system_repository)],
+    session: Annotated[AsyncSession, Depends(get_session)],
 ) -> ReadinessService:
-    return ReadinessService(repository=repository)
+    return ReadinessService(repository=repository, session=session)
 
 
 async def get_health_service(

--- a/src/system/routers.py
+++ b/src/system/routers.py
@@ -1,9 +1,7 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.core.database.session import get_session
 from src.core.utils.datetime_utils import get_utc_now
 from src.system.dependencies import get_health_service, get_readiness_service
 from src.system.schemas import HealthCheckResponse, ProbeResponse, ServerTimeResponse
@@ -23,10 +21,9 @@ async def check_liveness() -> ProbeResponse:
 @router.head("/ready/", response_model=ProbeResponse, include_in_schema=False)
 async def check_readiness(
     readiness_service: Annotated[ReadinessService, Depends(get_readiness_service)],
-    session: Annotated[AsyncSession, Depends(get_session)],
 ) -> ProbeResponse:
     """Readiness probe: reports whether the service can reach its database."""
-    await readiness_service.ensure_ready(session=session)
+    await readiness_service.ensure_ready()
     return ProbeResponse()
 
 
@@ -34,10 +31,9 @@ async def check_readiness(
 @router.head("/health/", response_model=HealthCheckResponse, include_in_schema=False)
 async def check_health(
     health_service: Annotated[HealthService, Depends(get_health_service)],
-    session: Annotated[AsyncSession, Depends(get_session)],
 ) -> HealthCheckResponse:
     """Detailed health report with the status of every dependency."""
-    return await health_service.get_status(session=session)
+    return await health_service.get_status()
 
 
 @router.get("/time/", response_model=ServerTimeResponse)

--- a/src/system/services.py
+++ b/src/system/services.py
@@ -26,10 +26,11 @@ class ReadinessService:
     of the load balancer.
     """
 
-    def __init__(self, repository: SystemRepository) -> None:
+    def __init__(self, repository: SystemRepository, session: AsyncSession) -> None:
         self.repository = repository
+        self.session = session
 
-    async def ensure_ready(self, session: AsyncSession) -> None:
+    async def ensure_ready(self) -> None:
         """
         Gate readiness on PostgreSQL only - the single dependency without which
         the service cannot answer any meaningful request.
@@ -40,13 +41,13 @@ class ReadinessService:
                 timeout (HTTP 503). Not logged here: the handler logs every
                 503 once, and a polling probe must not log an outage twice.
         """
-        if not await self.check_postgres(session):
+        if not await self.check_postgres():
             raise ServiceUnavailableException(
                 "Readiness check failed: PostgreSQL is unreachable",
                 additional_info={"postgres": False},
             )
 
-    async def check_postgres(self, session: AsyncSession) -> bool:
+    async def check_postgres(self) -> bool:
         """
         Catches everything on purpose: a host that does not resolve reaches the
         probe as a bare socket.gaierror from the driver, never wrapped into
@@ -55,7 +56,7 @@ class ReadinessService:
         """
         try:
             async with asyncio.timeout(POSTGRES_PROBE_TIMEOUT_SECONDS):
-                await self.repository.ping(session)
+                await self.repository.ping(self.session)
             return True
         except Exception as exc:
             logger.warning("Postgres health check failed: %s", exc)
@@ -77,7 +78,7 @@ class HealthService:
         self.redis_client = redis_client
         self.readiness = readiness
 
-    async def get_status(self, session: AsyncSession) -> HealthCheckResponse:
+    async def get_status(self) -> HealthCheckResponse:
         """
         Report the state of every dependency.
 
@@ -85,7 +86,7 @@ class HealthService:
         dependency is down, so it must keep answering with a body exactly when
         something is broken. /ready/ is what turns a Postgres outage into a 503.
         """
-        postgres_is_ok = await self.readiness.check_postgres(session)
+        postgres_is_ok = await self.readiness.check_postgres()
         redis_is_ok = await self._check_redis()
         is_healthy = postgres_is_ok and redis_is_ok
         return HealthCheckResponse(

--- a/src/user/dependencies.py
+++ b/src/user/dependencies.py
@@ -1,3 +1,9 @@
+from typing import Annotated
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.database.session import get_session
 from src.user.repositories import UserRepository
 from src.user.services import UserService
 
@@ -6,7 +12,8 @@ def get_user_repository() -> UserRepository:
     return UserRepository()
 
 
-def get_user_service() -> UserService:
-    return UserService(
-        repository=get_user_repository(),
-    )
+def get_user_service(
+    repository: Annotated[UserRepository, Depends(get_user_repository)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> UserService:
+    return UserService(repository=repository, session=session)

--- a/src/user/routers.py
+++ b/src/user/routers.py
@@ -7,11 +7,9 @@ from fastapi import (
     Request,
     Response,
 )
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.cache.decorators import cached_route
 from src.core.cache.interface import CacheScope
-from src.core.database.session import get_session
 from src.core.limiter.depends import RateLimiter
 from src.core.schemas import SuccessResponse
 from src.user.auth.cookies import TokenCookieResponder, get_token_cookie_responder
@@ -78,12 +76,11 @@ async def get_user_info_by_id(
         Depends(require_self_or_permission("user_id", Permission.VIEW_USERS)),
     ],
     user_service: Annotated[UserService, Depends(get_user_service)],
-    session: Annotated[AsyncSession, Depends(get_session)],
 ) -> UserSummaryViewModel:
     """
     Returns public information about a user by their identifier.
     """
-    user = await user_service.get_single_or_404(session, id=user_id)
+    user = await user_service.get_single_or_404(id=user_id)
     return UserSummaryViewModel.model_validate(user)
 
 

--- a/src/user/services.py
+++ b/src/user/services.py
@@ -1,3 +1,5 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from src.core.services import BaseService
 from src.user.auth.schemas import CreateUserModel
 from src.user.models import User
@@ -11,5 +13,6 @@ class UserService(
     def __init__(
         self,
         repository: UserRepository,
+        session: AsyncSession,
     ):
-        super().__init__(repository, response_schema=UserSummaryViewModel)
+        super().__init__(repository, session, response_schema=UserSummaryViewModel)

--- a/tests/unit/src/core/test_base_service_listing.py
+++ b/tests/unit/src/core/test_base_service_listing.py
@@ -39,11 +39,12 @@ async def test_base_service_passes_list_query_to_repository() -> None:
     repository.get_paginated_list = AsyncMock(return_value=([], 0))
     service: BaseService[
         ServiceModel, ServiceModelView, ServiceModelRepository, ServiceModelView
-    ] = BaseService(repository=repository, response_schema=ServiceModelView)
+    ] = BaseService(
+        repository=repository, session=AsyncMock(), response_schema=ServiceModelView
+    )
     list_query = ListQuery(search="alpha", order_by="name", order="asc")
 
     response = await service.get_paginated_list(
-        session=AsyncMock(),
         pagination=PaginationParams(page=1, size=10),
         query=list_query,
         is_active=True,

--- a/tests/unit/src/system/test_system_routers.py
+++ b/tests/unit/src/system/test_system_routers.py
@@ -21,7 +21,7 @@ class FakeHealthService:
     def __init__(self, response: HealthCheckResponse) -> None:
         self.response = response
 
-    async def get_status(self, session) -> HealthCheckResponse:
+    async def get_status(self) -> HealthCheckResponse:
         return self.response
 
 
@@ -104,13 +104,11 @@ async def test_check_readiness_returns_503_when_database_is_down(
 async def test_check_health_endpoint(
     app: FastAPI,
     dependency_overrides: DependencyOverrides,
-    fake_session: FakeAsyncSession,
 ) -> None:
     status = HealthCheckResponse(status="degraded", postgres=True, redis=False)
     dependency_overrides.set(
         get_health_service, ProvideValue(FakeHealthService(status))
     )
-    dependency_overrides.set(get_session, ProvideAsyncValue(fake_session))
 
     transport = httpx2.ASGITransport(app=app)
     async with httpx2.AsyncClient(

--- a/tests/unit/src/system/test_system_services.py
+++ b/tests/unit/src/system/test_system_services.py
@@ -23,12 +23,12 @@ class RedisFail:
         raise RuntimeError("down")
 
 
-def build_readiness() -> ReadinessService:
-    return ReadinessService(repository=SystemRepository())
+def build_readiness(session: FakeAsyncSession) -> ReadinessService:
+    return ReadinessService(repository=SystemRepository(), session=session)
 
 
-def build_service(redis_client: object) -> HealthService:
-    return HealthService(redis_client=redis_client, readiness=build_readiness())
+def build_service(redis_client: object, session: FakeAsyncSession) -> HealthService:
+    return HealthService(redis_client=redis_client, readiness=build_readiness(session))
 
 
 @pytest.mark.asyncio
@@ -37,7 +37,7 @@ async def test_health_service_ok(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("sentry_sdk.capture_exception", sentry_mock)
     session = FakeAsyncSession()
 
-    result = await build_service(RedisOk()).get_status(session=session)
+    result = await build_service(RedisOk(), session).get_status()
 
     assert result.status == "ok"
     assert result.postgres is True
@@ -53,7 +53,7 @@ async def test_health_service_redis_failure_degrades(
     monkeypatch.setattr("sentry_sdk.capture_exception", sentry_mock)
     session = FakeAsyncSession()
 
-    result = await build_service(RedisFail()).get_status(session=session)
+    result = await build_service(RedisFail(), session).get_status()
 
     assert result.status == "degraded"
     assert result.postgres is True
@@ -71,7 +71,7 @@ async def test_health_service_reports_postgres_failure_without_raising(
     session = FakeAsyncSession()
     session.execute = AsyncMock(side_effect=SQLAlchemyError("fail"))
 
-    result = await build_service(RedisOk()).get_status(session=session)
+    result = await build_service(RedisOk(), session).get_status()
 
     assert result.status == "degraded"
     assert result.postgres is False
@@ -81,7 +81,7 @@ async def test_health_service_reports_postgres_failure_without_raising(
 
 @pytest.mark.asyncio
 async def test_ensure_ready_passes_on_live_database() -> None:
-    await build_readiness().ensure_ready(FakeAsyncSession())
+    await build_readiness(FakeAsyncSession()).ensure_ready()
 
 
 @pytest.mark.asyncio
@@ -90,7 +90,7 @@ async def test_ensure_ready_raises_on_dead_database() -> None:
     session.execute = AsyncMock(side_effect=SQLAlchemyError("fail"))
 
     with pytest.raises(ServiceUnavailableException):
-        await build_readiness().ensure_ready(session)
+        await build_readiness(session).ensure_ready()
 
 
 @pytest.mark.asyncio
@@ -102,7 +102,7 @@ async def test_ensure_ready_raises_on_unresolvable_host() -> None:
     )
 
     with pytest.raises(ServiceUnavailableException):
-        await build_readiness().ensure_ready(session)
+        await build_readiness(session).ensure_ready()
 
 
 @pytest.mark.asyncio
@@ -119,4 +119,4 @@ async def test_ensure_ready_raises_when_the_probe_times_out(
     session.execute = never_answers
 
     with pytest.raises(ServiceUnavailableException):
-        await build_readiness().ensure_ready(session)
+        await build_readiness(session).ensure_ready()

--- a/tests/unit/src/user/services/test_user_service.py
+++ b/tests/unit/src/user/services/test_user_service.py
@@ -33,10 +33,10 @@ async def test_user_service_create_passes_full_payload(
 ) -> None:
     user = object()
     repo = FakeRepository(user)
-    service = UserService(repository=repo)
+    service = UserService(repository=repo, session=fake_session)
     payload = CreateSchema(email="test@example.com", full_name="Test User")
 
-    result = await service.create(fake_session, payload)
+    result = await service.create(payload)
 
     assert result is user
     repo.create.assert_awaited_once_with(
@@ -50,9 +50,9 @@ async def test_user_service_create_passes_full_payload(
 async def test_user_service_get_single(fake_session: FakeAsyncSession) -> None:
     user = object()
     repo = FakeRepository(user)
-    service = UserService(repository=repo)
+    service = UserService(repository=repo, session=fake_session)
 
-    result = await service.get_single(fake_session, id="user-id")
+    result = await service.get_single(id="user-id")
 
     assert result is user
     repo.get_single.assert_awaited_once()
@@ -64,10 +64,10 @@ async def test_user_service_update_uses_partial_model_dump(
 ) -> None:
     user = object()
     repo = FakeRepository(user)
-    service = UserService(repository=repo)
+    service = UserService(repository=repo, session=fake_session)
     payload = UpdateSchema(full_name="Updated User")
 
-    result = await service.update(fake_session, payload, id="user-id")
+    result = await service.update(payload, id="user-id")
 
     assert result is user
     repo.update.assert_awaited_once_with(

--- a/tests/unit/src/user/test_user_cache.py
+++ b/tests/unit/src/user/test_user_cache.py
@@ -8,7 +8,7 @@ import httpx2
 import pytest
 
 from src.core.cache.memory_cache import InMemoryCache
-from src.core.database.session import get_session, get_unit_of_work
+from src.core.database.session import get_unit_of_work
 from src.user.auth.dependencies import get_current_user
 from src.user.cache_keys import USER_CACHE_TAG, user_cache_keys
 from src.user.dependencies import get_user_service
@@ -52,7 +52,6 @@ async def test_summary_key_is_namespaced_per_user() -> None:
 async def test_tag_flush_drops_cached_summaries_of_every_user(
     async_client: httpx2.AsyncClient,
     dependency_overrides: DependencyOverrides,
-    fake_session: FakeAsyncSession,
     cache: InMemoryCache,
 ) -> None:
     # The tag is what a bulk write reaches for: one call clears both users, where
@@ -62,14 +61,13 @@ async def test_tag_flush_drops_cached_summaries_of_every_user(
     second_user = build_user()
     users = {first_user.id: first_user, second_user.id: second_user}
 
-    async def get_by_id(session: FakeAsyncSession, **filters: Any) -> User:
+    async def get_by_id(**filters: Any) -> User:
         return users[filters["id"]]
 
     user_service = FakeUserService(first_user)
     user_service.get_single_or_404 = AsyncMock(side_effect=get_by_id)
     dependency_overrides.set(get_current_user, ProvideValue(admin_user))
     dependency_overrides.set(get_user_service, ProvideValue(user_service))
-    dependency_overrides.set(get_session, ProvideAsyncValue(fake_session))
 
     await async_client.get(f"/v1/users/{first_user.id}")
     await async_client.get(f"/v1/users/{second_user.id}")
@@ -96,7 +94,6 @@ def test_namespace_collapses_non_canonical_uuid_spellings_to_one_key() -> None:
 async def test_get_user_by_id_serves_second_request_from_cache(
     async_client: httpx2.AsyncClient,
     dependency_overrides: DependencyOverrides,
-    fake_session: FakeAsyncSession,
     cache: InMemoryCache,
 ) -> None:
     admin_user = build_user(role=UserRole.ADMIN)
@@ -105,7 +102,6 @@ async def test_get_user_by_id_serves_second_request_from_cache(
     dependency_overrides.set(
         get_user_service, ProvideValue(FakeUserService(target_user))
     )
-    dependency_overrides.set(get_session, ProvideAsyncValue(fake_session))
 
     first = await async_client.get(f"/v1/users/{target_user.id}")
     second = await async_client.get(f"/v1/users/{target_user.id}")
@@ -128,7 +124,6 @@ async def test_profile_update_invalidates_cached_summary(
     user = build_user(role=UserRole.ADMIN)
     dependency_overrides.set(get_current_user, ProvideValue(user))
     dependency_overrides.set(get_user_service, ProvideValue(FakeUserService(user)))
-    dependency_overrides.set(get_session, ProvideAsyncValue(fake_session))
 
     async def apply_update(
         session: FakeAsyncSession, data: dict[str, Any], **filters: object
@@ -166,7 +161,6 @@ async def test_cache_invalidation_ignores_uuid_spelling_in_the_url(
     user = build_user(role=UserRole.ADMIN)
     dependency_overrides.set(get_current_user, ProvideValue(user))
     dependency_overrides.set(get_user_service, ProvideValue(FakeUserService(user)))
-    dependency_overrides.set(get_session, ProvideAsyncValue(fake_session))
 
     async def apply_update(
         session: FakeAsyncSession, data: dict[str, Any], **filters: object

--- a/tests/unit/src/user/test_user_routes.py
+++ b/tests/unit/src/user/test_user_routes.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from src.core.database.session import get_session
 from src.core.errors.exceptions import (
     InstanceNotFoundException,
     InstanceProcessingException,
@@ -24,10 +23,9 @@ from src.user.schemas import UserProfileViewModel
 from src.user.usecases.update_password import get_update_user_password_use_case
 from src.user.usecases.update_profile import get_update_user_profile_use_case
 from tests.factories.user_factory import build_user
-from tests.fakes.db import FakeAsyncSession
 from tests.helpers.limiter import noop_rate_limiter
 from tests.helpers.overrides import DependencyOverrides
-from tests.helpers.providers import ProvideAsyncValue, ProvideValue
+from tests.helpers.providers import ProvideValue
 
 
 class FakeUpdatePasswordUseCase:
@@ -107,7 +105,6 @@ async def test_get_user_profile_exposes_blocked_state(
 async def test_get_user_info_by_id(
     async_client,
     dependency_overrides: DependencyOverrides,
-    fake_session: FakeAsyncSession,
 ) -> None:
     admin_user = build_user(role=UserRole.ADMIN)
     target_user = build_user()
@@ -115,7 +112,6 @@ async def test_get_user_info_by_id(
     dependency_overrides.set(
         get_user_service, ProvideValue(FakeUserService(target_user))
     )
-    dependency_overrides.set(get_session, ProvideAsyncValue(fake_session))
 
     response = await async_client.get(f"/v1/users/{target_user.id}")
 
@@ -129,7 +125,6 @@ async def test_get_user_info_by_id(
 async def test_get_user_info_by_id_denies_without_view_users_permission(
     async_client,
     dependency_overrides: DependencyOverrides,
-    fake_session: FakeAsyncSession,
 ) -> None:
     # When a VIEWER tries to access another user's ID without VIEW_USERS permission,
     # the BOLA guard returns 404 to prevent enumeration: the response is indistinguishable
@@ -140,7 +135,6 @@ async def test_get_user_info_by_id_denies_without_view_users_permission(
     dependency_overrides.set(
         get_user_service, ProvideValue(FakeUserService(target_user))
     )
-    dependency_overrides.set(get_session, ProvideAsyncValue(fake_session))
 
     response = await async_client.get(f"/v1/users/{target_user.id}")
 
@@ -155,13 +149,11 @@ async def test_get_user_info_by_id_denies_without_view_users_permission(
 async def test_get_user_info_by_id_returns_404_when_user_is_missing(
     async_client,
     dependency_overrides: DependencyOverrides,
-    fake_session: FakeAsyncSession,
 ) -> None:
     admin_user = build_user(role=UserRole.ADMIN)
     missing_user_id = build_user().id
     dependency_overrides.set(get_current_user, ProvideValue(admin_user))
     dependency_overrides.set(get_user_service, ProvideValue(FakeUserService(None)))
-    dependency_overrides.set(get_session, ProvideAsyncValue(fake_session))
 
     response = await async_client.get(f"/v1/users/{missing_user_id}")
 


### PR DESCRIPTION
Routers no longer receive a DB session. `BaseService` takes the session in its constructor from the service's DI provider; all CRUD methods drop their session parameter and use the stored one. `get_user_service` now injects `UserRepository` and `AsyncSession` via `Annotated` dependencies. In the system module the session moved from the `/ready/` and `/health/` endpoints into `get_readiness_service`; `HealthService.get_status()` delegates the postgres check to `ReadinessService`. Repositories are unchanged and stay stateless with an explicit session argument.

`docs/readme/architecture.md` documents the rule: a router must never import `AsyncSession` or `get_session`, with no exceptions.

Testing: full unit suite (794 tests) and lint green; router/service tests updated to the new signatures without weakening assertions.