### PR TITLE
chore: reconcile integration-suite docs and migration test with the merged waves

### DIFF
--- a/docs/readme/infra.md
+++ b/docs/readme/infra.md
@@ -111,7 +111,7 @@ make clean            # remove stack + volumes/images/orphans
 ## Troubleshooting
 - Ensure Docker/Compose are installed.
 - `.env` must be filled (ports, DB/Redis credentials). `.env.test` used for local test runs `make test` / `make test-cov`.
-- Host-side integration tests that connect to `localhost` (per `.env.test`) need the backing-service ports, which are published on `127.0.0.1` only in dev — start the stack with `make run-dev` first. `make run` / `make up` do not publish them.
+- The integration suite (`make test-integration`) brings up its own throwaway PostgreSQL from `infra/docker-compose.test.yml` and overrides the connection settings itself — it needs Docker, but not a running dev stack.
 - Use `make logs` or service-specific logs to inspect errors.
 - If migrations fail, check Postgres health first.
 

--- a/tests/integration/src/core/database/test_migrations.py
+++ b/tests/integration/src/core/database/test_migrations.py
@@ -16,7 +16,7 @@ from tests.integration.conftest import REPO_ROOT
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
-EXPECTED_TABLES = {"users", "outbox_messages"}
+EXPECTED_TABLES = {"users", "notes", "outbox_messages"}
 
 
 async def test_chain_applies_to_a_clean_database(


### PR DESCRIPTION
Two follow-ups from the whole-branch review of the waves 4+5 merges.

- `docs/readme/infra.md`: the troubleshooting note still told integration runs to start the dev stack; the suite has run against its own throwaway container since #163.
- `tests/integration/.../test_migrations.py`: add `notes` (#162) to `EXPECTED_TABLES` so the clean-database assertion covers the newest table.

Testing: `make test-integration` 15 passed; lint clean.