### PR TITLE
refactor(uow): drop the unused UnitOfWork generic

### DIFF
--- a/scripts/create_admin.py
+++ b/scripts/create_admin.py
@@ -16,7 +16,7 @@ from pydantic import EmailStr, ValidationError
 
 from loggers import get_logger
 from src.core.database.session import tasks_async_session
-from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
+from src.core.database.uow import ApplicationUnitOfWork
 from src.core.schemas import (
     Base,
     EmailNormalizationMixin,
@@ -52,7 +52,7 @@ class _AdminCredentialsModel(
 
 
 async def ensure_admin(
-    uow: ApplicationUnitOfWork[RepositoryProtocol],
+    uow: ApplicationUnitOfWork,
     *,
     email: str,
     password: str,
@@ -145,7 +145,7 @@ async def main() -> None:
     phone_number = os.environ.get("ADMIN_PHONE") or DEFAULT_PHONE_NUMBER
 
     async with tasks_async_session() as session:
-        uow: ApplicationUnitOfWork[RepositoryProtocol] = ApplicationUnitOfWork(session)
+        uow: ApplicationUnitOfWork = ApplicationUnitOfWork(session)
         try:
             await ensure_admin(
                 uow,

--- a/src/core/database/session.py
+++ b/src/core/database/session.py
@@ -5,7 +5,7 @@ from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.core.database.engine import engine, tasks_engine
-from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol, get_uow
+from src.core.database.uow import ApplicationUnitOfWork, get_uow
 
 async_session = async_sessionmaker(bind=engine, expire_on_commit=False)
 tasks_async_session = async_sessionmaker(bind=tasks_engine, expire_on_commit=False)
@@ -18,7 +18,7 @@ async def get_session() -> AsyncGenerator[AsyncSession]:
 
 async def get_unit_of_work(
     session: Annotated[AsyncSession, Depends(get_session)],
-) -> AsyncGenerator[ApplicationUnitOfWork[RepositoryProtocol]]:
+) -> AsyncGenerator[ApplicationUnitOfWork]:
     """
     Dependency injection function that provides a Unit of Work instance.
 

--- a/src/core/database/uow/__init__.py
+++ b/src/core/database/uow/__init__.py
@@ -1,4 +1,4 @@
-from src.core.database.uow.abstract import R, RepositoryProtocol, UnitOfWork
+from src.core.database.uow.abstract import UnitOfWork
 from src.core.database.uow.application import ApplicationUnitOfWork, get_uow
 from src.core.database.uow.sqlalchemy import (
     RepositoryInstance,
@@ -6,9 +6,7 @@ from src.core.database.uow.sqlalchemy import (
 )
 
 __all__ = [
-    "RepositoryProtocol",
     "RepositoryInstance",
-    "R",
     "UnitOfWork",
     "SQLAlchemyUnitOfWork",
     "ApplicationUnitOfWork",

--- a/src/core/database/uow/abstract.py
+++ b/src/core/database/uow/abstract.py
@@ -1,30 +1,18 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Any, ClassVar, Generic, Protocol, TypeVar
+from typing import Any
 
 
-class RepositoryProtocol(Protocol):
-    """Protocol defining the structure of a repository class."""
-
-    model: ClassVar[Any]
-
-
-R = TypeVar("R", bound=RepositoryProtocol)
-
-
-class UnitOfWork(ABC, Generic[R]):
+class UnitOfWork(ABC):
     """
     Abstract Unit of Work interface that defines the contract for concrete UoW implementations.
 
     The Unit of Work pattern provides an abstraction over the transaction boundary
     and encapsulates all repositories needed for business operations within a single unit.
-
-    Generics:
-        R: Repository type bound to RepositoryProtocol, to enable type hinting for repositories
     """
 
     @abstractmethod
-    async def __aenter__(self) -> "UnitOfWork[R]":
+    async def __aenter__(self) -> "UnitOfWork":
         """Enter the context manager, starting a transaction if needed."""
 
     @abstractmethod

--- a/src/core/database/uow/application.py
+++ b/src/core/database/uow/application.py
@@ -3,14 +3,13 @@ from typing import Any, cast
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.database.repositories import BaseRepository
-from src.core.database.uow.abstract import R, RepositoryProtocol
 from src.core.database.uow.sqlalchemy import RepositoryInstance, SQLAlchemyUnitOfWork
 from src.core.outbox.repositories import OutboxRepository
 from src.note.repositories import NoteRepository
 from src.user.repositories import UserRepository
 
 
-class ApplicationUnitOfWork(SQLAlchemyUnitOfWork[R]):
+class ApplicationUnitOfWork(SQLAlchemyUnitOfWork):
     """
     Application-specific Unit of Work implementation.
 
@@ -71,7 +70,7 @@ class ApplicationUnitOfWork(SQLAlchemyUnitOfWork[R]):
     # Add more repository properties as needed
 
 
-async def get_uow(session: AsyncSession) -> ApplicationUnitOfWork[RepositoryProtocol]:
+async def get_uow(session: AsyncSession) -> ApplicationUnitOfWork:
     """
     Dependency injection function to get an ApplicationUnitOfWork instance.
     This DI assumes the AsyncSession has already been created and is injected here.

--- a/src/core/database/uow/sqlalchemy.py
+++ b/src/core/database/uow/sqlalchemy.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from loggers import get_logger
 from src.core.database.repositories import BaseRepository
 from src.core.database.transactions import safe_begin
-from src.core.database.uow.abstract import R, UnitOfWork
+from src.core.database.uow.abstract import UnitOfWork
 
 # Type variable for repository instances
 RepositoryInstance = TypeVar("RepositoryInstance", bound=BaseRepository[Any])
@@ -17,15 +17,12 @@ logger = get_logger(__name__)
 AfterCommitHook = Callable[[], Awaitable[None]]
 
 
-class SQLAlchemyUnitOfWork(UnitOfWork[R]):
+class SQLAlchemyUnitOfWork(UnitOfWork):
     """
     SQLAlchemy implementation of the Unit of Work pattern.
 
     This implementation uses SQLAlchemy's AsyncSession for transaction management
     and allows registration of repositories.
-
-    Generics:
-        R: Repository type bound to RepositoryProtocol, to enable type hinting for repositories
     """
 
     def __init__(self, session: AsyncSession):

--- a/src/core/outbox/dispatcher.py
+++ b/src/core/outbox/dispatcher.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from taskiq.decor import AsyncTaskiqDecoratedTask
 import uuid6
 
-from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
+from src.core.database.uow import ApplicationUnitOfWork
 from src.core.outbox.repositories import OutboxRepository
 
 
@@ -29,7 +29,7 @@ class TaskDispatcher:
 
     async def enqueue_transactional(
         self,
-        uow: ApplicationUnitOfWork[RepositoryProtocol],
+        uow: ApplicationUnitOfWork,
         task: AsyncTaskiqDecoratedTask[Any, Any],
         *args: Any,
         **kwargs: Any,

--- a/src/core/outbox/tasks.py
+++ b/src/core/outbox/tasks.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from taskiq import TaskiqDepends
 
 from loggers import get_logger
-from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
+from src.core.database.uow import ApplicationUnitOfWork
 from src.core.outbox.models import OutboxMessage
 from src.core.utils.datetime_utils import get_utc_now
 from taskiq_worker.broker import broker
@@ -36,7 +36,7 @@ async def outbox_sweeper(
     """Publish pending outbox rows whose after-commit publish did not happen."""
     published = 0
     failed = 0
-    uow: ApplicationUnitOfWork[RepositoryProtocol] = ApplicationUnitOfWork(session)
+    uow: ApplicationUnitOfWork = ApplicationUnitOfWork(session)
     async with uow:
         batch = await uow.outbox.get_batch_for_publish(
             uow.session, limit=SWEEPER_BATCH_SIZE
@@ -81,7 +81,7 @@ async def outbox_purge(
 ) -> str:
     """Delete published outbox rows older than the retention window."""
     cutoff = get_utc_now() - timedelta(days=PUBLISHED_RETENTION_DAYS)
-    uow: ApplicationUnitOfWork[RepositoryProtocol] = ApplicationUnitOfWork(session)
+    uow: ApplicationUnitOfWork = ApplicationUnitOfWork(session)
     async with uow:
         deleted = await uow.outbox.purge_published(uow.session, cutoff)
         await uow.commit()

--- a/src/note/usecases/create_note.py
+++ b/src/note/usecases/create_note.py
@@ -5,7 +5,7 @@ from fastapi import Depends
 
 from loggers import get_logger
 from src.core.database.session import get_unit_of_work
-from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
+from src.core.database.uow import ApplicationUnitOfWork
 from src.note.schemas import NoteCreateModel, NoteViewModel
 
 logger = get_logger(__name__)
@@ -38,7 +38,7 @@ class CreateNoteUseCase:
     - NoteViewModel: the created note.
     """
 
-    def __init__(self, uow: ApplicationUnitOfWork[RepositoryProtocol]) -> None:
+    def __init__(self, uow: ApplicationUnitOfWork) -> None:
         self.uow = uow
 
     async def execute(self, data: NoteCreateModel, owner_id: UUID) -> NoteViewModel:
@@ -53,8 +53,6 @@ class CreateNoteUseCase:
 
 
 def get_create_note_use_case(
-    uow: Annotated[
-        ApplicationUnitOfWork[RepositoryProtocol], Depends(get_unit_of_work)
-    ],
+    uow: Annotated[ApplicationUnitOfWork, Depends(get_unit_of_work)],
 ) -> CreateNoteUseCase:
     return CreateNoteUseCase(uow=uow)

--- a/src/note/usecases/delete_note.py
+++ b/src/note/usecases/delete_note.py
@@ -5,7 +5,7 @@ from fastapi import Depends
 
 from loggers import get_logger
 from src.core.database.session import get_unit_of_work
-from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
+from src.core.database.uow import ApplicationUnitOfWork
 from src.core.errors.exceptions import InstanceNotFoundException
 from src.note.policies import ensure_note_access
 from src.user.auth.permissions.enum import Permission
@@ -46,7 +46,7 @@ class DeleteNoteUseCase:
     - None.
     """
 
-    def __init__(self, uow: ApplicationUnitOfWork[RepositoryProtocol]) -> None:
+    def __init__(self, uow: ApplicationUnitOfWork) -> None:
         self.uow = uow
 
     async def execute(self, note_id: UUID, current_user: User) -> None:
@@ -70,8 +70,6 @@ class DeleteNoteUseCase:
 
 
 def get_delete_note_use_case(
-    uow: Annotated[
-        ApplicationUnitOfWork[RepositoryProtocol], Depends(get_unit_of_work)
-    ],
+    uow: Annotated[ApplicationUnitOfWork, Depends(get_unit_of_work)],
 ) -> DeleteNoteUseCase:
     return DeleteNoteUseCase(uow=uow)

--- a/src/note/usecases/update_note.py
+++ b/src/note/usecases/update_note.py
@@ -5,7 +5,7 @@ from fastapi import Depends
 
 from loggers import get_logger
 from src.core.database.session import get_unit_of_work
-from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
+from src.core.database.uow import ApplicationUnitOfWork
 from src.core.errors.exceptions import InstanceNotFoundException
 from src.note.policies import ensure_note_access
 from src.note.schemas import NoteUpdateModel, NoteViewModel
@@ -50,7 +50,7 @@ class UpdateNoteUseCase:
     - NoteViewModel: the updated note.
     """
 
-    def __init__(self, uow: ApplicationUnitOfWork[RepositoryProtocol]) -> None:
+    def __init__(self, uow: ApplicationUnitOfWork) -> None:
         self.uow = uow
 
     async def execute(
@@ -85,8 +85,6 @@ class UpdateNoteUseCase:
 
 
 def get_update_note_use_case(
-    uow: Annotated[
-        ApplicationUnitOfWork[RepositoryProtocol], Depends(get_unit_of_work)
-    ],
+    uow: Annotated[ApplicationUnitOfWork, Depends(get_unit_of_work)],
 ) -> UpdateNoteUseCase:
     return UpdateNoteUseCase(uow=uow)

--- a/src/user/auth/services/email_notifier.py
+++ b/src/user/auth/services/email_notifier.py
@@ -6,7 +6,7 @@ from redis.asyncio import Redis
 from taskiq.decor import AsyncTaskiqDecoratedTask
 
 from loggers import get_logger
-from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
+from src.core.database.uow import ApplicationUnitOfWork
 from src.core.errors.exceptions import InstanceProcessingException
 from src.core.outbox.dependencies import get_task_dispatcher
 from src.core.outbox.dispatcher import TaskDispatcher
@@ -71,7 +71,7 @@ class EmailNotifier:
     async def send(
         self,
         *,
-        uow: ApplicationUnitOfWork[RepositoryProtocol],
+        uow: ApplicationUnitOfWork,
         user: User,
         throttle_key: str | None = None,
     ) -> None:

--- a/src/user/auth/usecases/login.py
+++ b/src/user/auth/usecases/login.py
@@ -8,7 +8,7 @@ from loggers import get_logger
 from src.core.cache.dependencies import get_cache
 from src.core.cache.interface import Cache
 from src.core.database.session import get_unit_of_work
-from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
+from src.core.database.uow import ApplicationUnitOfWork
 from src.core.redis.dependencies import get_redis_client
 from src.core.schemas import TokenModel
 from src.core.utils.security import (
@@ -71,7 +71,7 @@ class LoginUserUseCase:
 
     def __init__(
         self,
-        uow: ApplicationUnitOfWork[RepositoryProtocol],
+        uow: ApplicationUnitOfWork,
         redis_client: Redis,
         cache: Cache,
     ) -> None:
@@ -128,7 +128,7 @@ class LoginUserUseCase:
 
     async def _rehash_password_if_needed(
         self,
-        uow: ApplicationUnitOfWork[RepositoryProtocol],
+        uow: ApplicationUnitOfWork,
         user: User,
         raw_password: str,
     ) -> None:
@@ -143,9 +143,7 @@ class LoginUserUseCase:
 
 
 def get_login_user_use_case(
-    uow: Annotated[
-        ApplicationUnitOfWork[RepositoryProtocol], Depends(get_unit_of_work)
-    ],
+    uow: Annotated[ApplicationUnitOfWork, Depends(get_unit_of_work)],
     redis_client: Annotated[Redis, Depends(get_redis_client)],
     cache: Annotated[Cache, Depends(get_cache)],
 ) -> LoginUserUseCase:

--- a/src/user/auth/usecases/register.py
+++ b/src/user/auth/usecases/register.py
@@ -4,7 +4,7 @@ from fastapi import Depends
 
 from loggers import get_logger
 from src.core.database.session import get_unit_of_work
-from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
+from src.core.database.uow import ApplicationUnitOfWork
 from src.core.utils.security import hash_password
 from src.user.auth.schemas import CreateUserModel
 from src.user.auth.services.email_notifier import (
@@ -47,7 +47,7 @@ class RegisterUseCase:
 
     def __init__(
         self,
-        uow: ApplicationUnitOfWork[RepositoryProtocol],
+        uow: ApplicationUnitOfWork,
         notifier: EmailNotifier,
     ) -> None:
         self.uow = uow
@@ -72,9 +72,7 @@ class RegisterUseCase:
 
 
 def get_register_use_case(
-    uow: Annotated[
-        ApplicationUnitOfWork[RepositoryProtocol], Depends(get_unit_of_work)
-    ],
+    uow: Annotated[ApplicationUnitOfWork, Depends(get_unit_of_work)],
     notifier: Annotated[EmailNotifier, Depends(get_verification_notifier)],
 ) -> RegisterUseCase:
     return RegisterUseCase(uow=uow, notifier=notifier)

--- a/src/user/auth/usecases/resend_verification.py
+++ b/src/user/auth/usecases/resend_verification.py
@@ -4,7 +4,7 @@ from fastapi import Depends
 
 from loggers import get_logger
 from src.core.database.session import get_unit_of_work
-from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
+from src.core.database.uow import ApplicationUnitOfWork
 from src.core.errors.exceptions import InstanceProcessingException
 from src.core.schemas import SuccessResponse
 from src.core.utils.security import build_email_throttle_key, mask_email
@@ -48,7 +48,7 @@ class SendVerificationUseCase:
 
     def __init__(
         self,
-        uow: ApplicationUnitOfWork[RepositoryProtocol],
+        uow: ApplicationUnitOfWork,
         notifier: EmailNotifier,
     ) -> None:
         self.uow = uow
@@ -96,9 +96,7 @@ class SendVerificationUseCase:
 
 
 def get_send_verification_use_case(
-    uow: Annotated[
-        ApplicationUnitOfWork[RepositoryProtocol], Depends(get_unit_of_work)
-    ],
+    uow: Annotated[ApplicationUnitOfWork, Depends(get_unit_of_work)],
     notifier: Annotated[EmailNotifier, Depends(get_verification_notifier)],
 ) -> SendVerificationUseCase:
     return SendVerificationUseCase(uow=uow, notifier=notifier)

--- a/src/user/auth/usecases/reset_password_confirm.py
+++ b/src/user/auth/usecases/reset_password_confirm.py
@@ -8,7 +8,7 @@ from loggers import get_logger
 from src.core.cache.dependencies import get_cache
 from src.core.cache.interface import Cache
 from src.core.database.session import get_unit_of_work
-from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
+from src.core.database.uow import ApplicationUnitOfWork
 from src.core.errors.exceptions import UnauthorizedException
 from src.core.redis.dependencies import get_redis_client
 from src.core.schemas import SuccessResponse
@@ -64,7 +64,7 @@ class ResetPasswordConfirmUseCase:
 
     def __init__(
         self,
-        uow: ApplicationUnitOfWork[RepositoryProtocol],
+        uow: ApplicationUnitOfWork,
         redis_client: Redis,
         cache: Cache,
     ) -> None:
@@ -133,9 +133,7 @@ class ResetPasswordConfirmUseCase:
 
 
 def get_reset_password_confirm_use_case(
-    uow: Annotated[
-        ApplicationUnitOfWork[RepositoryProtocol], Depends(get_unit_of_work)
-    ],
+    uow: Annotated[ApplicationUnitOfWork, Depends(get_unit_of_work)],
     redis_client: Annotated[Redis, Depends(get_redis_client)],
     cache: Annotated[Cache, Depends(get_cache)],
 ) -> ResetPasswordConfirmUseCase:

--- a/src/user/auth/usecases/reset_password_request.py
+++ b/src/user/auth/usecases/reset_password_request.py
@@ -4,7 +4,7 @@ from fastapi import Depends
 
 from loggers import get_logger
 from src.core.database.session import get_unit_of_work
-from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
+from src.core.database.uow import ApplicationUnitOfWork
 from src.core.errors.exceptions import InstanceProcessingException
 from src.core.schemas import SuccessResponse
 from src.core.utils.security import build_email_throttle_key, mask_email
@@ -47,7 +47,7 @@ class ResetPasswordRequestUseCase:
 
     def __init__(
         self,
-        uow: ApplicationUnitOfWork[RepositoryProtocol],
+        uow: ApplicationUnitOfWork,
         notifier: EmailNotifier,
     ) -> None:
         self.uow = uow
@@ -94,9 +94,7 @@ class ResetPasswordRequestUseCase:
 
 
 def get_reset_password_request_use_case(
-    uow: Annotated[
-        ApplicationUnitOfWork[RepositoryProtocol], Depends(get_unit_of_work)
-    ],
+    uow: Annotated[ApplicationUnitOfWork, Depends(get_unit_of_work)],
     notifier: Annotated[EmailNotifier, Depends(get_reset_password_notifier)],
 ) -> ResetPasswordRequestUseCase:
     return ResetPasswordRequestUseCase(uow=uow, notifier=notifier)

--- a/src/user/auth/usecases/verify_email.py
+++ b/src/user/auth/usecases/verify_email.py
@@ -8,7 +8,7 @@ from loggers import get_logger
 from src.core.cache.dependencies import get_cache
 from src.core.cache.interface import Cache
 from src.core.database.session import get_unit_of_work
-from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
+from src.core.database.uow import ApplicationUnitOfWork
 from src.core.errors.exceptions import UnauthorizedException
 from src.core.redis.dependencies import get_redis_client
 from src.core.schemas import SuccessResponse
@@ -57,7 +57,7 @@ class VerifyEmailUseCase:
 
     def __init__(
         self,
-        uow: ApplicationUnitOfWork[RepositoryProtocol],
+        uow: ApplicationUnitOfWork,
         redis_client: Redis,
         cache: Cache,
     ) -> None:
@@ -128,9 +128,7 @@ class VerifyEmailUseCase:
 
 
 def get_verify_email_use_case(
-    uow: Annotated[
-        ApplicationUnitOfWork[RepositoryProtocol], Depends(get_unit_of_work)
-    ],
+    uow: Annotated[ApplicationUnitOfWork, Depends(get_unit_of_work)],
     redis_client: Annotated[Redis, Depends(get_redis_client)],
     cache: Annotated[Cache, Depends(get_cache)],
 ) -> VerifyEmailUseCase:

--- a/src/user/tasks.py
+++ b/src/user/tasks.py
@@ -7,7 +7,7 @@ from taskiq import TaskiqDepends
 
 from loggers import get_logger
 from src.core.database.filters import FilterCondition
-from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
+from src.core.database.uow import ApplicationUnitOfWork
 from src.core.utils.datetime_utils import get_utc_now
 from taskiq_worker.broker import broker
 from taskiq_worker.dependencies import get_tasks_session
@@ -43,7 +43,7 @@ async def cleanup_unverified_users(
     not a silent violation of the "every user-row write bumps the namespace" rule.
     """
     cutoff = get_utc_now() - UNVERIFIED_USER_MAX_AGE
-    uow: ApplicationUnitOfWork[RepositoryProtocol] = ApplicationUnitOfWork(session)
+    uow: ApplicationUnitOfWork = ApplicationUnitOfWork(session)
     try:
         async with uow:
             deleted_count = await uow.users.batch_soft_delete(

--- a/src/user/usecases/update_password.py
+++ b/src/user/usecases/update_password.py
@@ -8,7 +8,7 @@ from loggers import get_logger
 from src.core.cache.dependencies import get_cache
 from src.core.cache.interface import Cache
 from src.core.database.session import get_unit_of_work
-from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
+from src.core.database.uow import ApplicationUnitOfWork
 from src.core.errors.exceptions import (
     InstanceNotFoundException,
     InstanceProcessingException,
@@ -66,7 +66,7 @@ class UpdateUserPasswordUseCase:
 
     def __init__(
         self,
-        uow: ApplicationUnitOfWork[RepositoryProtocol],
+        uow: ApplicationUnitOfWork,
         redis_client: Redis,
         cache: Cache,
     ) -> None:
@@ -116,9 +116,7 @@ class UpdateUserPasswordUseCase:
 
 
 def get_update_user_password_use_case(
-    uow: Annotated[
-        ApplicationUnitOfWork[RepositoryProtocol], Depends(get_unit_of_work)
-    ],
+    uow: Annotated[ApplicationUnitOfWork, Depends(get_unit_of_work)],
     redis_client: Annotated[Redis, Depends(get_redis_client)],
     cache: Annotated[Cache, Depends(get_cache)],
 ) -> UpdateUserPasswordUseCase:

--- a/src/user/usecases/update_profile.py
+++ b/src/user/usecases/update_profile.py
@@ -7,7 +7,7 @@ from loggers import get_logger
 from src.core.cache.dependencies import get_cache
 from src.core.cache.interface import Cache
 from src.core.database.session import get_unit_of_work
-from src.core.database.uow import ApplicationUnitOfWork, RepositoryProtocol
+from src.core.database.uow import ApplicationUnitOfWork
 from src.core.errors.exceptions import InstanceNotFoundException
 from src.user.cache_keys import user_cache_keys
 from src.user.schemas import UserProfileUpdateModel, UserProfileViewModel
@@ -51,7 +51,7 @@ class UpdateUserProfileUseCase:
 
     def __init__(
         self,
-        uow: ApplicationUnitOfWork[RepositoryProtocol],
+        uow: ApplicationUnitOfWork,
         cache: Cache,
     ) -> None:
         self.uow = uow
@@ -76,9 +76,7 @@ class UpdateUserProfileUseCase:
 
 
 def get_update_user_profile_use_case(
-    uow: Annotated[
-        ApplicationUnitOfWork[RepositoryProtocol], Depends(get_unit_of_work)
-    ],
+    uow: Annotated[ApplicationUnitOfWork, Depends(get_unit_of_work)],
     cache: Annotated[Cache, Depends(get_cache)],
 ) -> UpdateUserProfileUseCase:
     return UpdateUserProfileUseCase(uow=uow, cache=cache)

--- a/tests/integration/src/core/database/test_uow.py
+++ b/tests/integration/src/core/database/test_uow.py
@@ -13,7 +13,6 @@ import pytest_asyncio
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
-from src.core.database.uow.abstract import RepositoryProtocol
 from src.core.database.uow.application import ApplicationUnitOfWork
 from src.core.utils.security import password_hasher
 from src.user.enums import UserRole
@@ -64,7 +63,7 @@ async def test_commit_is_visible_to_another_session(
     username = f"commit-{uuid4().hex[:8]}"
 
     async with AsyncSession(integration_engine, expire_on_commit=False) as session:
-        uow: ApplicationUnitOfWork[RepositoryProtocol] = ApplicationUnitOfWork(session)
+        uow: ApplicationUnitOfWork = ApplicationUnitOfWork(session)
         async with uow:
             created = await uow.users.create(uow.session, build_user_data(username))
             await uow.flush()
@@ -84,7 +83,7 @@ async def test_rollback_leaves_nothing_behind(
     username = f"rollback-{uuid4().hex[:8]}"
 
     async with AsyncSession(integration_engine, expire_on_commit=False) as session:
-        uow: ApplicationUnitOfWork[RepositoryProtocol] = ApplicationUnitOfWork(session)
+        uow: ApplicationUnitOfWork = ApplicationUnitOfWork(session)
         async with uow:
             await uow.users.create(uow.session, build_user_data(username))
             await uow.flush()
@@ -100,7 +99,7 @@ async def test_repository_commit_inside_a_uow_is_refused(
     db_session: AsyncSession, integration_engine: AsyncEngine
 ) -> None:
     """The guard has to hold on a real session, where a stray COMMIT is irreversible."""
-    uow: ApplicationUnitOfWork[RepositoryProtocol] = ApplicationUnitOfWork(db_session)
+    uow: ApplicationUnitOfWork = ApplicationUnitOfWork(db_session)
     username = f"guard-{uuid4().hex[:8]}"
 
     async with uow:

--- a/tests/integration/src/core/outbox/test_outbox.py
+++ b/tests/integration/src/core/outbox/test_outbox.py
@@ -7,7 +7,6 @@ and the commit are actually tied together.
 """
 
 from collections.abc import AsyncGenerator
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID
 
@@ -17,7 +16,6 @@ from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from taskiq import InMemoryBroker
 
-from src.core.database.uow.abstract import RepositoryProtocol
 from src.core.database.uow.application import ApplicationUnitOfWork
 from src.core.outbox.dispatcher import TaskDispatcher
 from src.core.outbox.enums import OutboxMessageStatus
@@ -80,7 +78,7 @@ async def read_message(engine: AsyncEngine, message_id: UUID) -> OutboxMessage |
         return await OutboxRepository().get_single(session, id=message_id)
 
 
-async def enqueued_id(uow: ApplicationUnitOfWork[Any]) -> UUID:
+async def enqueued_id(uow: ApplicationUnitOfWork) -> UUID:
     """Id of the row the UoW's outbox repository just staged.
 
     The read flushes the staged INSERT, which is also what makes it visible to the
@@ -99,7 +97,7 @@ async def test_commit_persists_the_row_and_publishes_it(
     committed_message_ids: list[UUID],
 ) -> None:
     async with AsyncSession(integration_engine, expire_on_commit=False) as session:
-        uow: ApplicationUnitOfWork[RepositoryProtocol] = ApplicationUnitOfWork(session)
+        uow: ApplicationUnitOfWork = ApplicationUnitOfWork(session)
         async with uow:
             await dispatcher.enqueue_transactional(uow, probe_task, "hello", flag=True)
             message_id = await enqueued_id(uow)
@@ -127,7 +125,7 @@ async def test_rollback_discards_the_row_and_publishes_nothing(
     publish_spy: AsyncMock,
 ) -> None:
     async with AsyncSession(integration_engine, expire_on_commit=False) as session:
-        uow: ApplicationUnitOfWork[RepositoryProtocol] = ApplicationUnitOfWork(session)
+        uow: ApplicationUnitOfWork = ApplicationUnitOfWork(session)
         async with uow:
             await dispatcher.enqueue_transactional(uow, probe_task, "dropped")
             message_id = await enqueued_id(uow)
@@ -151,7 +149,7 @@ async def test_pending_row_is_the_sweeper_batch_after_a_failed_publish(
     publish_spy.side_effect = RuntimeError("broker unreachable")
 
     async with AsyncSession(integration_engine, expire_on_commit=False) as session:
-        uow: ApplicationUnitOfWork[RepositoryProtocol] = ApplicationUnitOfWork(session)
+        uow: ApplicationUnitOfWork = ApplicationUnitOfWork(session)
         async with uow:
             await dispatcher.enqueue_transactional(uow, probe_task, "retry-me")
             message_id = await enqueued_id(uow)


### PR DESCRIPTION
Removes the `Generic[R]` parameter from `UnitOfWork`/`SQLAlchemyUnitOfWork`/`ApplicationUnitOfWork` and the `RepositoryProtocol` that existed only to bound it.

The parameter never appeared in a single method signature — repositories are exposed as concretely typed properties (`uow.users`, `uow.notes`, `uow.outbox`), so the annotation `ApplicationUnitOfWork[RepositoryProtocol]` repeated across every usecase, task and script added ceremony without any type information. mypy loses nothing.

`AsyncExitStack` in the UoW is deliberately kept: entering/exiting `safe_begin` is split across `__aenter__`/`__aexit__`, and the stack forwards exception info into the context manager correctly for free.

Testing: 867 unit passed, 15 integration passed, lint clean.