### PR TITLE
fix(repositories): enforce the filter guard in SoftDeleteRepository update/delete

### DIFF
--- a/src/core/database/repositories.py
+++ b/src/core/database/repositories.py
@@ -416,6 +416,9 @@ class SoftDeleteRepository(BaseRepository[T], Generic[T]):
         **filters: Any,
     ) -> T | None:
         """Update a record where is_deleted flag is False, using the filters."""
+        # Guard before the setdefault below: seeding is_deleted first would make
+        # the base-class filter check pass for a filter-less call.
+        self._ensure_filters_present(filters)
         filters.setdefault("is_deleted", False)
         return await super().update(session, data, commit, **filters)
 
@@ -423,6 +426,7 @@ class SoftDeleteRepository(BaseRepository[T], Generic[T]):
         self, session: AsyncSession, commit: bool = False, **filters: Any
     ) -> T | None:
         """Soft delete a record, using the filters."""
+        self._ensure_filters_present(filters)
         if commit:
             self._ensure_commit_allowed(session)
         filters.setdefault("is_deleted", False)

--- a/tests/unit/src/core/database/test_database_repositories.py
+++ b/tests/unit/src/core/database/test_database_repositories.py
@@ -618,6 +618,28 @@ def test_soft_delete_repository_requires_fields() -> None:
 
 
 @pytest.mark.asyncio
+async def test_soft_delete_repository_update_requires_filters() -> None:
+    repo = RepositorySoftDeleteRepository()
+    session = RepositorySession()
+
+    with pytest.raises(ValueError):
+        await repo.update(session=session, data={"name": "new"})
+
+    session.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_repository_delete_requires_filters() -> None:
+    repo = RepositorySoftDeleteRepository()
+    session = RepositorySession()
+
+    with pytest.raises(ValueError):
+        await repo.delete(session=session)
+
+    session.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_soft_delete_repository_marks_instance_and_commits(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
SoftDeleteRepository.update seeded filters with is_deleted=False before delegating, so BaseRepository._ensure_filters_present never saw an empty dict; delete skipped the guard entirely. A filter-less call therefore silently mutated or soft-deleted an arbitrary row (unordered .first()), while the base class correctly raises ValueError. Both domain repositories are soft-delete, so the guard was dead in every domain.

The guard now runs first in both overrides; batch_soft_delete already had its own has_conditions() check and is untouched.

Testing: new unit tests assert filter-less update/delete raise ValueError and never reach the session; full suite green (869 passed), lint green.