### PR TITLE
fix(uow): roll back on exit without an explicit commit

### DIFF
--- a/docs/readme/architecture.md
+++ b/docs/readme/architecture.md
@@ -8,6 +8,7 @@ The `src/core/database/uow/` package keeps DB work transactional and coordinates
 - Transaction management: groups multiple DB operations to succeed or fail together.
 - Repository coordination: single transaction boundary for multiple repositories.
 - Clean API design: consistent interface (`commit`, `rollback`) for callers.
+- Exit contract: leaving the UoW context without an explicit `commit()` rolls the transaction back - commit is never implicit.
 
 Implementations:
 - `UnitOfWork`: abstract contract (`uow/abstract.py`).

--- a/src/core/database/uow/sqlalchemy.py
+++ b/src/core/database/uow/sqlalchemy.py
@@ -1,12 +1,10 @@
 from collections.abc import Awaitable, Callable, Sequence
-from contextlib import AsyncExitStack
 from typing import Any, Self, TypeVar
 
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, AsyncSessionTransaction
 
 from loggers import get_logger
 from src.core.database.repositories import BaseRepository
-from src.core.database.transactions import safe_begin
 from src.core.database.uow.abstract import UnitOfWork
 
 # Type variable for repository instances
@@ -36,7 +34,7 @@ class SQLAlchemyUnitOfWork(UnitOfWork):
             session: The SQLAlchemy AsyncSession to use for database operations
         """
         self._session = session
-        self._exit_stack = AsyncExitStack()  # noqa
+        self._transaction: AsyncSessionTransaction | None = None
         self._is_completed = False
         self._after_commit_hooks: list[AfterCommitHook] = []
 
@@ -44,11 +42,19 @@ class SQLAlchemyUnitOfWork(UnitOfWork):
         """
         Enter the context manager and start a transaction.
 
+        Keeps a handle on the transaction it opened (a SAVEPOINT when the
+        session is already in one - the normal case for authenticated requests,
+        where the auth dependency's SELECT has autobegun on the shared request
+        session), so rollback can target exactly this UoW's scope instead of
+        the whole session transaction.
+
         Returns:
             self: The UnitOfWork instance
         """
-        await self._exit_stack.__aenter__()
-        await self._exit_stack.enter_async_context(safe_begin(self._session))
+        if self._session.in_transaction():
+            self._transaction = await self._session.begin_nested()
+        else:
+            self._transaction = await self._session.begin()
         self._session.info["uow_active"] = True
         return self
 
@@ -75,8 +81,8 @@ class SQLAlchemyUnitOfWork(UnitOfWork):
                         "changes were pending; rolling back."
                     )
                 await self.rollback()
-            await self._exit_stack.__aexit__(exc_type, exc_val, exc_tb)
         finally:
+            self._transaction = None
             self._session.info.pop("uow_active", None)
 
     def _has_pending_changes(self) -> bool:
@@ -107,13 +113,22 @@ class SQLAlchemyUnitOfWork(UnitOfWork):
 
     async def rollback(self) -> None:
         """
-        Rollback the transaction.
+        Rollback this UoW's transaction scope.
+
+        Rolls back only the transaction this UoW opened: on the nested path
+        that is the SAVEPOINT, so uncommitted work the caller staged on the
+        shared session before entering the UoW survives. Without the handle
+        (rollback outside the context), the whole session transaction is
+        rolled back.
 
         Raises:
             RuntimeError: If the unit of work has already been completed
         """
         self._ensure_not_completed()
-        await self._session.rollback()
+        if self._transaction is not None:
+            await self._transaction.rollback()
+        else:
+            await self._session.rollback()
         self._is_completed = True
         self._after_commit_hooks = []
 

--- a/src/core/database/uow/sqlalchemy.py
+++ b/src/core/database/uow/sqlalchemy.py
@@ -23,6 +23,9 @@ class SQLAlchemyUnitOfWork(UnitOfWork):
 
     This implementation uses SQLAlchemy's AsyncSession for transaction management
     and allows registration of repositories.
+
+    Commit is strictly explicit: leaving the context without calling commit()
+    rolls the transaction back, whether the block raised or returned normally.
     """
 
     def __init__(self, session: AsyncSession):
@@ -51,7 +54,13 @@ class SQLAlchemyUnitOfWork(UnitOfWork):
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         """
-        Exit the context manager and close the session.
+        Exit the context manager.
+
+        Any exit without a prior commit() rolls back. Without this, a clean
+        exit's outcome would depend on invisible context: a fresh session's
+        `begin()` block commits on clean exit, while a shared request session
+        (every authenticated route) releases the SAVEPOINT and discards the
+        work later at session close.
 
         Args:
             exc_type: Exception type if an exception was raised
@@ -59,11 +68,21 @@ class SQLAlchemyUnitOfWork(UnitOfWork):
             exc_tb: Exception traceback if an exception was raised
         """
         try:
-            if exc_type is not None and not self._is_completed:
+            if not self._is_completed:
+                if exc_type is None and self._has_pending_changes():
+                    logger.warning(
+                        "UnitOfWork exited cleanly without commit() while "
+                        "changes were pending; rolling back."
+                    )
                 await self.rollback()
             await self._exit_stack.__aexit__(exc_type, exc_val, exc_tb)
         finally:
             self._session.info.pop("uow_active", None)
+
+    def _has_pending_changes(self) -> bool:
+        # Best-effort forgotten-commit detection: already-flushed changes are
+        # not visible in these collections, so silence proves nothing.
+        return bool(self._session.dirty or self._session.new or self._session.deleted)
 
     def _ensure_not_completed(self) -> None:
         if self._is_completed:

--- a/tests/fakes/db.py
+++ b/tests/fakes/db.py
@@ -1,18 +1,28 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Generator, Sequence
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 
 class AsyncTransactionContext:
+    """Stands in for AsyncSessionTransaction: awaitable like the real
+    `session.begin()` / `begin_nested()`, usable as an async CM."""
+
     def __init__(self, session: FakeAsyncSession) -> None:
         self._session = session
         self._was_in_transaction = session.in_transaction()
+        self.nested = self._was_in_transaction
 
-    async def __aenter__(self) -> AsyncTransactionContext:
+    async def start(self) -> AsyncTransactionContext:
         self._session.set_in_transaction(True)
         return self
+
+    def __await__(self) -> Generator[Any, None, AsyncTransactionContext]:
+        return self.start().__await__()
+
+    async def __aenter__(self) -> AsyncTransactionContext:
+        return await self.start()
 
     async def __aexit__(
         self,
@@ -23,6 +33,13 @@ class AsyncTransactionContext:
         if not self._was_in_transaction:
             self._session.set_in_transaction(False)
         return None
+
+    async def rollback(self) -> None:
+        # Forward to the session mock so tests can keep asserting on
+        # `session.rollback`; scope granularity is proven at integration level.
+        await self._session.rollback()
+        if not self._was_in_transaction:
+            self._session.set_in_transaction(False)
 
 
 class FakeAsyncSession:

--- a/tests/fakes/db.py
+++ b/tests/fakes/db.py
@@ -38,6 +38,11 @@ class FakeAsyncSession:
         # Mirrors real `AsyncSession.info`: a plain dict the UoW uses to mark
         # itself active for the repository commit guard.
         self.info: dict[str, Any] = {}
+        # Mirror the real session's pending-state views, consulted by the UoW's
+        # forgotten-commit warning on clean exit.
+        self.dirty: set[Any] = set()
+        self.new: set[Any] = set()
+        self.deleted: set[Any] = set()
 
     def in_transaction(self) -> bool:
         return self._in_transaction

--- a/tests/integration/src/core/database/test_uow_clean_exit.py
+++ b/tests/integration/src/core/database/test_uow_clean_exit.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.database.uow import ApplicationUnitOfWork
+from src.core.utils.security import password_hasher
+from src.user.enums import UserRole
+from src.user.models import User
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+def _user_data(tag: str) -> dict[str, Any]:
+    return {
+        "first_name": "Clean",
+        "last_name": "Exit",
+        "email": f"{tag}@example.com",
+        "username": tag,
+        "phone_number": f"+1{uuid4().int % 10**10:010d}",
+        "password_hash": password_hasher.hash("password"),
+        "role": UserRole.VIEWER,
+        "is_verified": True,
+        "is_active": True,
+    }
+
+
+async def test_clean_exit_without_commit_persists_nothing_on_fresh_session(
+    db_session: AsyncSession,
+) -> None:
+    tag = f"uow-clean-{uuid4().hex[:12]}"
+    uow = ApplicationUnitOfWork(db_session)
+    async with uow:
+        await uow.users.create(uow.session, data=_user_data(tag))
+
+    found = await db_session.scalar(select(User).where(User.username == tag))
+    assert found is None
+
+
+async def test_clean_exit_without_commit_discards_savepoint_work(
+    db_session: AsyncSession,
+) -> None:
+    # Mimic the authenticated-request path: a prior SELECT autobegins the
+    # outer transaction, so the UoW enters through begin_nested().
+    await db_session.execute(select(1))
+    tag = f"uow-nested-{uuid4().hex[:12]}"
+    uow = ApplicationUnitOfWork(db_session)
+    async with uow:
+        await uow.users.create(uow.session, data=_user_data(tag))
+
+    found = await db_session.scalar(select(User).where(User.username == tag))
+    assert found is None

--- a/tests/integration/src/core/database/test_uow_clean_exit.py
+++ b/tests/integration/src/core/database/test_uow_clean_exit.py
@@ -11,6 +11,7 @@ from src.core.database.uow import ApplicationUnitOfWork
 from src.core.utils.security import password_hasher
 from src.user.enums import UserRole
 from src.user.models import User
+from src.user.repositories import UserRepository
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -54,3 +55,23 @@ async def test_clean_exit_without_commit_discards_savepoint_work(
 
     found = await db_session.scalar(select(User).where(User.username == tag))
     assert found is None
+
+
+async def test_clean_exit_rolls_back_only_the_uow_savepoint(
+    db_session: AsyncSession,
+) -> None:
+    # Work the caller staged on the shared session before entering the UoW
+    # must survive the UoW's implicit rollback: only the SAVEPOINT goes.
+    outer_tag = f"uow-outer-{uuid4().hex[:12]}"
+    inner_tag = f"uow-inner-{uuid4().hex[:12]}"
+    await UserRepository().create(db_session, data=_user_data(outer_tag))
+    await db_session.flush()
+
+    uow = ApplicationUnitOfWork(db_session)
+    async with uow:
+        await uow.users.create(uow.session, data=_user_data(inner_tag))
+
+    outer = await db_session.scalar(select(User).where(User.username == outer_tag))
+    inner = await db_session.scalar(select(User).where(User.username == inner_tag))
+    assert outer is not None
+    assert inner is None

--- a/tests/unit/src/core/database/uow/test_database_uow.py
+++ b/tests/unit/src/core/database/uow/test_database_uow.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
 
 from src.core.database.uow.application import ApplicationUnitOfWork, get_uow
@@ -122,6 +124,43 @@ async def test_sqlalchemy_uow_aexit_skips_rollback_when_completed() -> None:
     await uow.__aenter__()
     await uow.commit()
     await uow.__aexit__(RuntimeError, RuntimeError("fail"), None)
+
+    session.rollback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sqlalchemy_uow_clean_exit_without_commit_rolls_back() -> None:
+    session = FakeAsyncSession()
+    uow = SQLAlchemyUnitOfWork(session)
+
+    async with uow:
+        pass
+
+    session.rollback.assert_awaited_once()
+    session.commit.assert_not_awaited()
+    assert uow.completed is True
+
+
+@pytest.mark.asyncio
+async def test_sqlalchemy_uow_clean_exit_skips_after_commit_hooks() -> None:
+    session = FakeAsyncSession()
+    uow = SQLAlchemyUnitOfWork(session)
+    hook = AsyncMock()
+
+    async with uow:
+        uow.add_after_commit_hook(hook)
+
+    hook.assert_not_awaited()
+    session.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sqlalchemy_uow_commit_then_clean_exit_does_not_roll_back() -> None:
+    session = FakeAsyncSession()
+    uow = SQLAlchemyUnitOfWork(session)
+
+    async with uow:
+        await uow.commit()
 
     session.rollback.assert_not_awaited()
 


### PR DESCRIPTION
SQLAlchemyUnitOfWork.__aexit__ rolled back only on exception. A clean exit without commit() was nondeterministic: on a fresh session, safe_begin's session.begin() block committed everything silently (skipping after-commit hooks); on the shared request session of every authenticated route, the SAVEPOINT was released and the work silently rolled back at session close. The same forgotten uow.commit() persisted on one route and discarded on another.

Exit without completion now always rolls back - commit is strictly explicit; a clean exit with pending changes logs a warning. The exit contract is documented in architecture.md.

Testing: unit tests cover rollback, hook suppression, and the committed path; a new integration test proves nothing persists on either the fresh-session or SAVEPOINT path against real Postgres. make test (870) and make test-integration (17) green.