### PR TITLE
refactor(note): one PATCH semantics and one RBAC place in the exemplar module

### DIFF
--- a/src/note/policies.py
+++ b/src/note/policies.py
@@ -2,9 +2,28 @@ from uuid import UUID
 
 from src.core.errors.exceptions import InstanceNotFoundException
 from src.note.models import Note
+from src.user.auth.permissions.enum import Permission
+from src.user.auth.permissions.role_matrix import has_permission
+from src.user.enums import UserRole
 
 
-def ensure_note_access(note: Note, user_id: UUID, *, has_permission: bool) -> None:
-    """Foreign note without permission answers 404 (anti-enumeration)."""
-    if note.owner_id != user_id and not has_permission:
+def _note_access_denied(
+    note: Note, user_id: UUID, *, has_role_permission: bool
+) -> bool:
+    return note.owner_id != user_id and not has_role_permission
+
+
+def ensure_note_view_access(note: Note, user_id: UUID, role: UserRole) -> None:
+    """Foreign note without VIEW_NOTES answers 404 (anti-enumeration)."""
+    if _note_access_denied(
+        note, user_id, has_role_permission=has_permission(role, Permission.VIEW_NOTES)
+    ):
+        raise InstanceNotFoundException("Note not found.")
+
+
+def ensure_note_manage_access(note: Note, user_id: UUID, role: UserRole) -> None:
+    """Foreign note without MANAGE_NOTES answers 404 (anti-enumeration)."""
+    if _note_access_denied(
+        note, user_id, has_role_permission=has_permission(role, Permission.MANAGE_NOTES)
+    ):
         raise InstanceNotFoundException("Note not found.")

--- a/src/note/routers.py
+++ b/src/note/routers.py
@@ -6,15 +6,13 @@ from fastapi import APIRouter, Depends, Query
 from src.core.database.filters import FilterCondition
 from src.core.pagination import ListQueryParams, PaginatedResponse
 from src.note.dependencies import get_note_service
-from src.note.policies import ensure_note_access
+from src.note.policies import ensure_note_view_access
 from src.note.schemas import NoteCreateModel, NoteUpdateModel, NoteViewModel
 from src.note.services import NoteService
 from src.note.usecases.create_note import CreateNoteUseCase, get_create_note_use_case
 from src.note.usecases.delete_note import DeleteNoteUseCase, get_delete_note_use_case
 from src.note.usecases.update_note import UpdateNoteUseCase, get_update_note_use_case
 from src.user.auth.dependencies import get_current_user
-from src.user.auth.permissions.enum import Permission
-from src.user.auth.permissions.role_matrix import ROLE_PERMISSIONS
 from src.user.models import User
 
 router = APIRouter()
@@ -58,10 +56,7 @@ async def get_note(
     Returns a single note by its identifier.
     """
     note = await note_service.get_single_or_404(id=note_id)
-    has_permission = Permission.VIEW_NOTES in ROLE_PERMISSIONS.get(
-        current_user.role, set()
-    )
-    ensure_note_access(note, current_user.id, has_permission=has_permission)
+    ensure_note_view_access(note, current_user.id, current_user.role)
     return NoteViewModel.model_validate(note)
 
 

--- a/src/note/schemas.py
+++ b/src/note/schemas.py
@@ -1,7 +1,9 @@
 from datetime import datetime
+from typing import Annotated
 from uuid import UUID
 
 from pydantic import Field, field_validator
+from pydantic.json_schema import SkipJsonSchema
 
 from src.core.schemas import Base
 
@@ -12,8 +14,14 @@ class NoteCreateModel(Base):
 
 
 class NoteUpdateModel(Base):
-    title: str | None = Field(None, min_length=1, max_length=255)
-    content: str | None = None
+    # SkipJsonSchema[None] keeps the field optional at runtime while removing
+    # the null branch from the OpenAPI contract - the validator below rejects
+    # an explicit null, so the schema must not advertise it. Constraints sit
+    # inside the str branch so they never apply to the None default.
+    title: (
+        Annotated[str, Field(min_length=1, max_length=255)] | SkipJsonSchema[None]
+    ) = None
+    content: str | SkipJsonSchema[None] = None
 
     @field_validator("title", "content")
     @classmethod

--- a/src/note/schemas.py
+++ b/src/note/schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from src.core.schemas import Base
 
@@ -14,6 +14,16 @@ class NoteCreateModel(Base):
 class NoteUpdateModel(Base):
     title: str | None = Field(None, min_length=1, max_length=255)
     content: str | None = None
+
+    @field_validator("title", "content")
+    @classmethod
+    def reject_explicit_null(cls, value: str | None) -> str:
+        # PATCH uses exclude_unset semantics: an omitted field never reaches this
+        # validator (defaults are not validated), so None here is always an
+        # explicit null - and both columns are non-nullable.
+        if value is None:
+            raise ValueError("Field cannot be null")
+        return value
 
 
 class NoteViewModel(Base):

--- a/src/note/usecases/delete_note.py
+++ b/src/note/usecases/delete_note.py
@@ -7,9 +7,7 @@ from loggers import get_logger
 from src.core.database.session import get_unit_of_work
 from src.core.database.uow import ApplicationUnitOfWork
 from src.core.errors.exceptions import InstanceNotFoundException
-from src.note.policies import ensure_note_access
-from src.user.auth.permissions.enum import Permission
-from src.user.auth.permissions.role_matrix import ROLE_PERMISSIONS
+from src.note.policies import ensure_note_manage_access
 from src.user.models import User
 
 logger = get_logger(__name__)
@@ -54,10 +52,7 @@ class DeleteNoteUseCase:
             note = await uow.notes.get_single(uow.session, id=note_id)
             if note is None:
                 raise InstanceNotFoundException("Note not found.")
-            has_permission = Permission.MANAGE_NOTES in ROLE_PERMISSIONS.get(
-                current_user.role, set()
-            )
-            ensure_note_access(note, current_user.id, has_permission=has_permission)
+            ensure_note_manage_access(note, current_user.id, current_user.role)
 
             deleted_note = await uow.notes.delete(uow.session, id=note_id)
             if deleted_note is None:

--- a/src/note/usecases/update_note.py
+++ b/src/note/usecases/update_note.py
@@ -7,10 +7,8 @@ from loggers import get_logger
 from src.core.database.session import get_unit_of_work
 from src.core.database.uow import ApplicationUnitOfWork
 from src.core.errors.exceptions import InstanceNotFoundException
-from src.note.policies import ensure_note_access
+from src.note.policies import ensure_note_manage_access
 from src.note.schemas import NoteUpdateModel, NoteViewModel
-from src.user.auth.permissions.enum import Permission
-from src.user.auth.permissions.role_matrix import ROLE_PERMISSIONS
 from src.user.models import User
 
 logger = get_logger(__name__)
@@ -61,10 +59,7 @@ class UpdateNoteUseCase:
             note = await uow.notes.get_single(uow.session, id=note_id)
             if note is None:
                 raise InstanceNotFoundException("Note not found.")
-            has_permission = Permission.MANAGE_NOTES in ROLE_PERMISSIONS.get(
-                current_user.role, set()
-            )
-            ensure_note_access(note, current_user.id, has_permission=has_permission)
+            ensure_note_manage_access(note, current_user.id, current_user.role)
 
             updated_note = await uow.notes.update(uow.session, update_data, id=note_id)
             if updated_note is None:

--- a/src/note/usecases/update_note.py
+++ b/src/note/usecases/update_note.py
@@ -21,7 +21,7 @@ class UpdateNoteUseCase:
     Inputs:
     - note_id: UUID of the note to update.
     - data: NoteUpdateModel with the fields to change; an omitted field is
-      left untouched.
+      left untouched (exclude_unset), an explicit null fails schema validation.
     - current_user: the caller, used for the ownership/permission check.
 
     Validations:
@@ -54,7 +54,7 @@ class UpdateNoteUseCase:
     async def execute(
         self, note_id: UUID, data: NoteUpdateModel, current_user: User
     ) -> NoteViewModel:
-        update_data = data.model_dump(exclude_none=True)
+        update_data = data.model_dump(exclude_unset=True)
         async with self.uow as uow:
             note = await uow.notes.get_single(uow.session, id=note_id)
             if note is None:

--- a/src/user/auth/permissions/checker.py
+++ b/src/user/auth/permissions/checker.py
@@ -6,7 +6,7 @@ from fastapi import Depends
 from src.user.auth.dependencies import get_current_user
 from src.user.auth.errors import PermissionDeniedError
 from src.user.auth.permissions.enum import Permission
-from src.user.auth.permissions.role_matrix import ROLE_PERMISSIONS
+from src.user.auth.permissions.role_matrix import has_permission
 from src.user.models import User
 
 
@@ -18,8 +18,7 @@ def require_permission(
     def checker(
         current_user: Annotated[User, Depends(get_current_user)],
     ) -> User:
-        permissions = ROLE_PERMISSIONS.get(current_user.role, set())
-        if required_permission not in permissions:
+        if not has_permission(current_user.role, required_permission):
             raise PermissionDeniedError("Permission denied")
         return current_user
 

--- a/src/user/auth/permissions/ownership.py
+++ b/src/user/auth/permissions/ownership.py
@@ -7,7 +7,7 @@ from fastapi import Depends, Request
 from src.core.errors.exceptions import InstanceNotFoundException
 from src.user.auth.dependencies import get_current_user
 from src.user.auth.permissions.enum import Permission
-from src.user.auth.permissions.role_matrix import ROLE_PERMISSIONS
+from src.user.auth.permissions.role_matrix import has_permission
 from src.user.models import User
 
 
@@ -50,7 +50,7 @@ def require_self_or_permission(
         object_id = request.path_params[path_param]
         if _matches_user_id(str(object_id), current_user.id):
             return current_user
-        if fallback in ROLE_PERMISSIONS.get(current_user.role, set()):
+        if has_permission(current_user.role, fallback):
             return current_user
         raise InstanceNotFoundException("User not found.")
 

--- a/src/user/auth/permissions/role_matrix.py
+++ b/src/user/auth/permissions/role_matrix.py
@@ -1,6 +1,12 @@
 from src.user.auth.permissions.enum import Permission
 from src.user.enums import UserRole
 
+
+def has_permission(role: UserRole, permission: Permission) -> bool:
+    """Single RBAC lookup for every guard: the role grants the permission or not."""
+    return permission in ROLE_PERMISSIONS.get(role, set())
+
+
 ROLE_PERMISSIONS: dict[UserRole, set[Permission]] = {
     # Admin - full system access for user-related functions
     UserRole.ADMIN: {

--- a/src/user/schemas.py
+++ b/src/user/schemas.py
@@ -12,10 +12,20 @@ class UserProfileUpdateModel(Base):
     last_name: str | None = Field(None, min_length=2, max_length=30)
     username: str | None = Field(None, min_length=3, max_length=50)
 
+    @field_validator("first_name", "last_name", "username")
+    @classmethod
+    def reject_explicit_null(cls, value: str | None) -> str:
+        # PATCH uses exclude_unset semantics: an omitted field never reaches this
+        # validator (defaults are not validated), so None here is always an
+        # explicit null - and all three columns are non-nullable.
+        if value is None:
+            raise ValueError("Field cannot be null")
+        return value
+
     @field_validator("first_name", "last_name")
     @classmethod
-    def validate_name(cls, value: str | None) -> str | None:
-        if value is not None and not FULL_NAME_PATTERN.match(value):
+    def validate_name(cls, value: str) -> str:
+        if not FULL_NAME_PATTERN.match(value):
             raise ValueError(
                 "Name must contain latin letters, with single spaces, "
                 "hyphens or apostrophes between parts"

--- a/src/user/schemas.py
+++ b/src/user/schemas.py
@@ -1,6 +1,8 @@
+from typing import Annotated
 from uuid import UUID
 
 from pydantic import EmailStr, Field, field_validator
+from pydantic.json_schema import SkipJsonSchema
 
 from src.core.schemas import Base
 from src.core.validations import FULL_NAME_PATTERN
@@ -8,9 +10,19 @@ from src.user.enums import UserRole
 
 
 class UserProfileUpdateModel(Base):
-    first_name: str | None = Field(None, min_length=2, max_length=30)
-    last_name: str | None = Field(None, min_length=2, max_length=30)
-    username: str | None = Field(None, min_length=3, max_length=50)
+    # SkipJsonSchema[None] keeps the fields optional at runtime while removing
+    # the null branch from the OpenAPI contract - the validator below rejects
+    # an explicit null, so the schema must not advertise it. Constraints sit
+    # inside the str branch so they never apply to the None default.
+    first_name: (
+        Annotated[str, Field(min_length=2, max_length=30)] | SkipJsonSchema[None]
+    ) = None
+    last_name: (
+        Annotated[str, Field(min_length=2, max_length=30)] | SkipJsonSchema[None]
+    ) = None
+    username: (
+        Annotated[str, Field(min_length=3, max_length=50)] | SkipJsonSchema[None]
+    ) = None
 
     @field_validator("first_name", "last_name", "username")
     @classmethod

--- a/src/user/usecases/update_profile.py
+++ b/src/user/usecases/update_profile.py
@@ -21,12 +21,11 @@ class UpdateUserProfileUseCase:
 
     Inputs:
     - data: UserProfileUpdateModel with the fields to change. A field left unset
-      is skipped rather than cleared; an explicit `null` is likewise skipped, not
-      rejected, since the schema has no way to tell "omitted" from "set to null"
-      apart from Pydantic's own unset-tracking, which this UseCase does not use.
-      An entirely empty body is a no-op write: it still updates zero columns,
-      still flushes, and still bumps the cache namespace. Both are the safe
-      direction - a spurious bump costs a cold cache, not a stale read.
+      is skipped (exclude_unset); an explicit `null` fails schema validation,
+      because every updatable column here is non-nullable. An entirely empty
+      body is a no-op write: it still updates zero columns, still flushes, and
+      still bumps the cache namespace - a spurious bump costs a cold cache, not
+      a stale read.
     - user_id: UUID of the user being updated.
 
     Validations:
@@ -60,7 +59,7 @@ class UpdateUserProfileUseCase:
     async def execute(
         self, data: UserProfileUpdateModel, user_id: UUID
     ) -> UserProfileViewModel:
-        update_data = data.model_dump(exclude_none=True)
+        update_data = data.model_dump(exclude_unset=True)
         async with self.uow as uow:
             updated_user = await uow.users.update(uow.session, update_data, id=user_id)
             if not updated_user:

--- a/tests/unit/src/note/test_note_policies.py
+++ b/tests/unit/src/note/test_note_policies.py
@@ -7,27 +7,32 @@ import pytest
 
 from src.core.errors.exceptions import InstanceNotFoundException
 from src.note import policies
+from src.user.enums import UserRole
 from tests.factories.note_factory import build_note
 
 
-def test_owner_without_permission_passes() -> None:
+def test_owner_without_permission_passes_view_and_manage() -> None:
     owner_id = uuid4()
     note = build_note(owner_id=owner_id)
 
-    policies.ensure_note_access(note, owner_id, has_permission=False)
+    policies.ensure_note_view_access(note, owner_id, UserRole.VIEWER)
+    policies.ensure_note_manage_access(note, owner_id, UserRole.VIEWER)
 
 
 def test_foreign_note_with_permission_passes() -> None:
     note = build_note(owner_id=uuid4())
 
-    policies.ensure_note_access(note, uuid4(), has_permission=True)
+    policies.ensure_note_view_access(note, uuid4(), UserRole.ADMIN)
+    policies.ensure_note_manage_access(note, uuid4(), UserRole.ADMIN)
 
 
 def test_foreign_note_without_permission_raises_not_found() -> None:
     note = build_note(owner_id=uuid4())
 
     with pytest.raises(InstanceNotFoundException):
-        policies.ensure_note_access(note, uuid4(), has_permission=False)
+        policies.ensure_note_view_access(note, uuid4(), UserRole.VIEWER)
+    with pytest.raises(InstanceNotFoundException):
+        policies.ensure_note_manage_access(note, uuid4(), UserRole.VIEWER)
 
 
 def test_policies_module_stays_pure() -> None:

--- a/tests/unit/src/note/test_note_schemas.py
+++ b/tests/unit/src/note/test_note_schemas.py
@@ -22,3 +22,12 @@ def test_note_update_omitted_field_stays_unset() -> None:
 def test_note_update_empty_body_dumps_empty() -> None:
     model = NoteUpdateModel.model_validate({})
     assert model.model_dump(exclude_unset=True) == {}
+
+
+def test_note_update_schema_does_not_advertise_null() -> None:
+    # The validator answers 422 to an explicit null, so the OpenAPI contract
+    # must not tell generated SDKs that null is acceptable.
+    schema = NoteUpdateModel.model_json_schema()
+    for field in ("title", "content"):
+        field_schema = schema["properties"][field]
+        assert "null" not in str(field_schema), field_schema

--- a/tests/unit/src/note/test_note_schemas.py
+++ b/tests/unit/src/note/test_note_schemas.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pydantic import ValidationError
+import pytest
+
+from src.note.schemas import NoteUpdateModel
+
+
+@pytest.mark.parametrize("field", ["title", "content"])
+def test_note_update_rejects_explicit_null(field: str) -> None:
+    # Both columns are non-nullable: with exclude_unset PATCH semantics an
+    # explicit null must fail validation instead of reaching the database.
+    with pytest.raises(ValidationError):
+        NoteUpdateModel.model_validate({field: None})
+
+
+def test_note_update_omitted_field_stays_unset() -> None:
+    model = NoteUpdateModel.model_validate({"title": "New title"})
+    assert model.model_dump(exclude_unset=True) == {"title": "New title"}
+
+
+def test_note_update_empty_body_dumps_empty() -> None:
+    model = NoteUpdateModel.model_validate({})
+    assert model.model_dump(exclude_unset=True) == {}

--- a/tests/unit/src/user/auth/test_role_matrix.py
+++ b/tests/unit/src/user/auth/test_role_matrix.py
@@ -1,0 +1,23 @@
+from src.user.auth.permissions.enum import Permission
+from src.user.auth.permissions.role_matrix import ROLE_PERMISSIONS, has_permission
+from src.user.enums import UserRole
+
+
+def test_has_permission_true_for_granted_permission() -> None:
+    assert has_permission(UserRole.ADMIN, Permission.MANAGE_NOTES) is True
+
+
+def test_has_permission_false_for_missing_permission() -> None:
+    assert has_permission(UserRole.VIEWER, Permission.MANAGE_NOTES) is False
+
+
+def test_has_permission_false_for_role_without_grants() -> None:
+    unknown_role = "ghost-role"
+    assert unknown_role not in ROLE_PERMISSIONS
+    assert has_permission(unknown_role, Permission.VIEW_NOTES) is False  # type: ignore[arg-type]
+
+
+def test_has_permission_matches_role_matrix_for_every_pair() -> None:
+    for role, granted in ROLE_PERMISSIONS.items():
+        for permission in Permission:
+            assert has_permission(role, permission) is (permission in granted)

--- a/tests/unit/src/user/test_user_schemas.py
+++ b/tests/unit/src/user/test_user_schemas.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pydantic import ValidationError
+import pytest
+
+from src.user.schemas import UserProfileUpdateModel
+
+
+@pytest.mark.parametrize("field", ["first_name", "last_name", "username"])
+def test_profile_update_rejects_explicit_null(field: str) -> None:
+    # All three columns are non-nullable: with exclude_unset PATCH semantics an
+    # explicit null must fail validation instead of reaching the database.
+    with pytest.raises(ValidationError):
+        UserProfileUpdateModel.model_validate({field: None})
+
+
+def test_profile_update_omitted_field_stays_unset() -> None:
+    model = UserProfileUpdateModel.model_validate({"username": "new-name"})
+    assert model.model_dump(exclude_unset=True) == {"username": "new-name"}

--- a/tests/unit/src/user/test_user_schemas.py
+++ b/tests/unit/src/user/test_user_schemas.py
@@ -17,3 +17,12 @@ def test_profile_update_rejects_explicit_null(field: str) -> None:
 def test_profile_update_omitted_field_stays_unset() -> None:
     model = UserProfileUpdateModel.model_validate({"username": "new-name"})
     assert model.model_dump(exclude_unset=True) == {"username": "new-name"}
+
+
+def test_profile_update_schema_does_not_advertise_null() -> None:
+    # The validator answers 422 to an explicit null, so the OpenAPI contract
+    # must not tell generated SDKs that null is acceptable.
+    schema = UserProfileUpdateModel.model_json_schema()
+    for field in ("first_name", "last_name", "username"):
+        field_schema = schema["properties"][field]
+        assert "null" not in str(field_schema), field_schema


### PR DESCRIPTION
Polishes the module documented as the copy source for new domains.

- PATCH standardized on exclude_unset (note + profile): an omitted field is untouched, an explicit null on a non-nullable column fails validation with 422 instead of being silently dropped.
- RBAC lookup deduplicated: pure has_permission(role, permission) next to ROLE_PERMISSIONS; require_permission and require_self_or_permission use it.
- The note access rule lives only in note/policies.py: ensure_note_view_access / ensure_note_manage_access (thin wrappers over one predicate), removing three hand-copied ROLE_PERMISSIONS checks from the router and usecases.

Testing: schema-level null-rejection and unset-tracking tests, policies unit tests; 885 unit tests green.