### PR TITLE
fix(core): defuse latent traps in config, repositories, outbox, limiter and cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,12 @@ POSTGRES_PASSWORD=example-postgres-password-not-real
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_DB=postgres
+# API pool; tasks pool serves the taskiq worker - DB_TASKS_POOL_SIZE +
+# DB_TASKS_MAX_OVERFLOW must cover --max-async-tasks (infra/docker-compose.yml).
+DB_POOL_SIZE=5
+DB_MAX_OVERFLOW=2
+DB_TASKS_POOL_SIZE=5
+DB_TASKS_MAX_OVERFLOW=15
 
 # Redis
 REDIS_HOST=redis

--- a/src/core/database/engine.py
+++ b/src/core/database/engine.py
@@ -9,21 +9,21 @@ POOL_RECYCLE_SECONDS = 60 * 30
 engine = create_async_engine(
     DATABASE_URL,
     echo=config.postgres.DB_ECHO,
-    pool_size=5,
-    max_overflow=2,
+    pool_size=config.postgres.DB_POOL_SIZE,
+    max_overflow=config.postgres.DB_MAX_OVERFLOW,
     pool_timeout=POOL_TIMEOUT_SECONDS,
     pool_recycle=POOL_RECYCLE_SECONDS,
     pool_pre_ping=True,
 )
 
-# Isolated pool for background-task workers. pool_size + max_overflow == 20
-# matches --max-async-tasks 20 on the worker command (infra/docker-compose.yml):
+# Isolated pool for background-task workers. Defaults sum to 20 to match
+# --max-async-tasks 20 on the worker command (infra/docker-compose.yml):
 # even if every concurrent task grabs a session, nobody hits pool_timeout.
 tasks_engine = create_async_engine(
     DATABASE_URL,
     echo=config.postgres.DB_ECHO,
-    pool_size=5,
-    max_overflow=15,
+    pool_size=config.postgres.DB_TASKS_POOL_SIZE,
+    max_overflow=config.postgres.DB_TASKS_MAX_OVERFLOW,
     pool_timeout=POOL_TIMEOUT_SECONDS,
     pool_recycle=POOL_RECYCLE_SECONDS,
     pool_pre_ping=True,

--- a/src/core/database/repositories.py
+++ b/src/core/database/repositories.py
@@ -1,6 +1,14 @@
 from typing import Any, Generic, TypeVar, cast
 
-from sqlalchemy import Enum as SAEnum, String, Table, func, select, update
+from sqlalchemy import (
+    Enum as SAEnum,
+    String,
+    Table,
+    func,
+    inspect as sqlalchemy_inspect,
+    select,
+    update,
+)
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
@@ -254,6 +262,13 @@ class BaseRepository(Generic[T]):
         if commit:
             self._ensure_commit_allowed(session)
         self._ensure_filters_present(filters)
+        # setattr with a mistyped key would silently attach a plain Python
+        # attribute the flush ignores - the caller believes the row changed.
+        unknown_fields = set(data) - set(sqlalchemy_inspect(self.model).attrs.keys())
+        if unknown_fields:
+            raise ValueError(
+                f"Unknown fields for {self.model.__name__}: {sorted(unknown_fields)}"
+            )
         try:
             query = select(self.model).filter_by(**filters)
             result = await session.execute(query)

--- a/src/core/database/repositories.py
+++ b/src/core/database/repositories.py
@@ -264,6 +264,10 @@ class BaseRepository(Generic[T]):
         self._ensure_filters_present(filters)
         # setattr with a mistyped key would silently attach a plain Python
         # attribute the flush ignores - the caller believes the row changed.
+        # Boundary: mapped attributes (columns and relationships) pass; hybrid
+        # properties and plain Python properties are rejected even when they
+        # have setters - a domain that needs to set one extends this guard
+        # deliberately instead of inheriting a silent hole.
         unknown_fields = set(data) - set(sqlalchemy_inspect(self.model).attrs.keys())
         if unknown_fields:
             raise ValueError(

--- a/src/core/database/transactions.py
+++ b/src/core/database/transactions.py
@@ -62,24 +62,3 @@ async def maybe_begin(session: AsyncSession) -> AsyncGenerator[None]:
     else:
         async with session.begin():
             yield
-
-
-@asynccontextmanager
-async def safe_begin(session: AsyncSession) -> AsyncGenerator[None]:
-    """
-    Context manager that guarantees a transactional scope for ORM operations.
-
-    - If the session is not already in a transaction, opens a regular transaction
-      (BEGIN...COMMIT/ROLLBACK).
-    - If the session is already in a transaction, creates a nested transaction
-      (SAVEPOINT) to allow local commit or rollback without affecting the outer transaction.
-
-    Args:
-        session (AsyncSession): The SQLAlchemy async session to manage.
-    """
-    if session.in_transaction():
-        async with session.begin_nested():
-            yield
-    else:
-        async with session.begin():
-            yield

--- a/src/core/database/uow/abstract.py
+++ b/src/core/database/uow/abstract.py
@@ -17,7 +17,9 @@ class UnitOfWork(ABC):
 
     @abstractmethod
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        """Exit the context manager, committing or rolling back the transaction."""
+        """Exit the context manager. Commit is strictly explicit: leaving the
+        context without a prior `commit()` rolls back the UoW's own transaction
+        scope, exception or not."""
 
     @abstractmethod
     async def commit(self) -> None:

--- a/src/core/limiter/depends.py
+++ b/src/core/limiter/depends.py
@@ -199,7 +199,10 @@ class RateLimiter:
             raise RuntimeError("FastAPILimiter must be initialized before use.")
 
         rate_key = await self.identifier(request)
-        endpoint_name = request.scope["endpoint"].__name__
+        # module.qualname, not bare __name__: two routers both naming an
+        # endpoint `create` must not share one rate-limit bucket.
+        endpoint = request.scope["endpoint"]
+        endpoint_name = f"{endpoint.__module__}.{endpoint.__qualname__}"
         key = f"{FastAPILimiter.prefix}:{rate_key}:{endpoint_name}"
         logger.debug(f"RateLimiter key: {key}")
         pexpire = await self._check_limit(key)

--- a/src/core/outbox/dispatcher.py
+++ b/src/core/outbox/dispatcher.py
@@ -38,14 +38,25 @@ class TaskDispatcher:
         **kwargs: Any,
     ) -> None:
         # Arguments are stored in a JSONB outbox row; a non-JSON value (UUID,
-        # datetime, model) would otherwise fail deep inside the INSERT flush.
+        # datetime, NaN, model) would otherwise fail deep inside the INSERT
+        # flush. The round-trip check additionally rejects values JSON merely
+        # coerces (int dict keys, nested tuples): the inline publish would send
+        # the original while a sweeper republish sends the coerced form - one
+        # task, two different payloads.
+        payload = {"args": list(args), "kwargs": kwargs}
         try:
-            json.dumps({"args": list(args), "kwargs": kwargs})
+            encoded_payload = json.dumps(payload, allow_nan=False)
         except (TypeError, ValueError) as exc:
             raise TypeError(
                 f"Arguments for task '{task.task_name}' must be JSON-serializable "
                 f"(they are stored in a JSONB outbox row): {exc}"
             ) from exc
+        if json.loads(encoded_payload) != payload:
+            raise TypeError(
+                f"Arguments for task '{task.task_name}' must survive a JSON "
+                "round-trip unchanged (a sweeper republish sends the stored "
+                "JSONB form): avoid int dict keys and nested tuples"
+            )
         # Client-side id: the hook needs it before flush, and it doubles as the
         # broker task_id so the worker-side dedup marker survives republishing.
         # uuid7 to match the model's UUID7IDMixin default — pre-generating the

--- a/src/core/outbox/dispatcher.py
+++ b/src/core/outbox/dispatcher.py
@@ -11,6 +11,38 @@ from src.core.database.uow import ApplicationUnitOfWork
 from src.core.outbox.repositories import OutboxRepository
 
 
+def _survives_json_round_trip(original: Any, decoded: Any) -> bool:
+    """
+    Type-strict deep equality between a value and its JSON round-trip.
+
+    Plain `==` is not enough: a `StrEnum` compares equal to its string, an
+    `IntEnum` to its int, and dict subclasses to plain dicts - yet the inline
+    publish would send the original object while a sweeper republish sends the
+    decoded primitive from the JSONB row.
+    """
+    if type(original) is not type(decoded):
+        return False
+    if type(original) is dict:
+        if len(original) != len(decoded):
+            return False
+        return all(
+            type(original_key) is type(decoded_key)
+            and original_key == decoded_key
+            and _survives_json_round_trip(original_value, decoded_value)
+            for (original_key, original_value), (decoded_key, decoded_value) in zip(
+                original.items(), decoded.items(), strict=True
+            )
+        )
+    if type(original) is list:
+        if len(original) != len(decoded):
+            return False
+        return all(
+            _survives_json_round_trip(original_item, decoded_item)
+            for original_item, decoded_item in zip(original, decoded, strict=True)
+        )
+    return bool(original == decoded)
+
+
 class TaskDispatcher:
     """Single entry point for enqueueing background tasks.
 
@@ -51,11 +83,11 @@ class TaskDispatcher:
                 f"Arguments for task '{task.task_name}' must be JSON-serializable "
                 f"(they are stored in a JSONB outbox row): {exc}"
             ) from exc
-        if json.loads(encoded_payload) != payload:
+        if not _survives_json_round_trip(payload, json.loads(encoded_payload)):
             raise TypeError(
                 f"Arguments for task '{task.task_name}' must survive a JSON "
                 "round-trip unchanged (a sweeper republish sends the stored "
-                "JSONB form): avoid int dict keys and nested tuples"
+                "JSONB form): avoid enums, int dict keys and nested tuples"
             )
         # Client-side id: the hook needs it before flush, and it doubles as the
         # broker task_id so the worker-side dedup marker survives republishing.

--- a/src/core/outbox/dispatcher.py
+++ b/src/core/outbox/dispatcher.py
@@ -1,4 +1,5 @@
 from functools import partial
+import json
 from typing import Any
 from uuid import UUID
 
@@ -16,6 +17,8 @@ class TaskDispatcher:
     `enqueue` fires immediately; `enqueue_transactional` stores the task as an
     outbox row inside the caller's transaction and publishes it best-effort
     after commit (the sweeper guarantees delivery if that publish fails).
+    Transactional arguments must be JSON-serializable - pass `str(uuid)`, ISO
+    datetimes and plain dicts, not model instances.
     """
 
     def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
@@ -34,6 +37,15 @@ class TaskDispatcher:
         *args: Any,
         **kwargs: Any,
     ) -> None:
+        # Arguments are stored in a JSONB outbox row; a non-JSON value (UUID,
+        # datetime, model) would otherwise fail deep inside the INSERT flush.
+        try:
+            json.dumps({"args": list(args), "kwargs": kwargs})
+        except (TypeError, ValueError) as exc:
+            raise TypeError(
+                f"Arguments for task '{task.task_name}' must be JSON-serializable "
+                f"(they are stored in a JSONB outbox row): {exc}"
+            ) from exc
         # Client-side id: the hook needs it before flush, and it doubles as the
         # broker task_id so the worker-side dedup marker survives republishing.
         # uuid7 to match the model's UUID7IDMixin default — pre-generating the

--- a/src/main/config.py
+++ b/src/main/config.py
@@ -226,6 +226,21 @@ class PostgresConfig(BaseModel):
 
     model_config = ConfigDict(extra="ignore")
 
+    @field_validator("POSTGRES_DB")
+    @classmethod
+    def reject_url_breaking_database_name(cls, value: str) -> str:
+        # Credentials are percent-encoded in the DSN, but SQLAlchemy's make_url
+        # does not decode the database path segment, so encoding the name here
+        # would silently connect to a differently-named database. Failing fast
+        # is the only honest option for these characters.
+        forbidden = set("/?#@: ")
+        if any(character in forbidden for character in value):
+            raise ValueError(
+                "POSTGRES_DB must not contain '/', '?', '#', '@', ':' or spaces: "
+                "such a name cannot be represented in a database URL"
+            )
+        return value
+
     @property
     def dsn_async(self) -> str:
         # quote(safe="") because generated credentials routinely contain @ / % :

--- a/src/main/config.py
+++ b/src/main/config.py
@@ -229,15 +229,14 @@ class PostgresConfig(BaseModel):
     @field_validator("POSTGRES_DB")
     @classmethod
     def reject_url_breaking_database_name(cls, value: str) -> str:
-        # Credentials are percent-encoded in the DSN, but SQLAlchemy's make_url
-        # does not decode the database path segment, so encoding the name here
-        # would silently connect to a differently-named database. Failing fast
-        # is the only honest option for these characters.
-        forbidden = set("/?#@: ")
-        if any(character in forbidden for character in value):
+        # SQLAlchemy's make_url treats everything after '?' as the query string
+        # and does not decode the database path segment, so a name with '?' can
+        # be neither passed raw (truncated) nor percent-encoded (renamed).
+        # Every other character survives make_url unchanged and is allowed.
+        if "?" in value:
             raise ValueError(
-                "POSTGRES_DB must not contain '/', '?', '#', '@', ':' or spaces: "
-                "such a name cannot be represented in a database URL"
+                "POSTGRES_DB must not contain '?': such a name cannot be "
+                "represented in a database URL"
             )
         return value
 

--- a/src/main/config.py
+++ b/src/main/config.py
@@ -216,6 +216,14 @@ class PostgresConfig(BaseModel):
     POSTGRES_PORT: int
     POSTGRES_DB: str
 
+    DB_POOL_SIZE: int = Field(5, gt=0)
+    DB_MAX_OVERFLOW: int = Field(2, ge=0)
+    # Tasks pool size + overflow must cover --max-async-tasks on the worker
+    # command (infra/docker-compose.yml): every concurrent task may hold a
+    # session, and an undersized pool surfaces as pool_timeout errors.
+    DB_TASKS_POOL_SIZE: int = Field(5, gt=0)
+    DB_TASKS_MAX_OVERFLOW: int = Field(15, ge=0)
+
     model_config = ConfigDict(extra="ignore")
 
     @property

--- a/src/main/config.py
+++ b/src/main/config.py
@@ -2,7 +2,7 @@ from functools import lru_cache
 import json
 import os
 from typing import Any, Literal
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 from dotenv import dotenv_values
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -107,9 +107,11 @@ class RedisConfig(BaseModel):
 
     @property
     def dsn(self) -> str:
+        # quote(safe="") because generated passwords routinely contain @ / % :
+        # and every URL parser downstream would silently misread the DSN.
         return (
             f"redis://:"
-            f"{self.REDIS_PASSWORD}@"
+            f"{quote(self.REDIS_PASSWORD, safe='')}@"
             f"{self.REDIS_HOST}:"
             f"{self.REDIS_PORT}/"
             f"{self.REDIS_DATABASE}"
@@ -119,7 +121,7 @@ class RedisConfig(BaseModel):
     def tasks_dsn(self) -> str:
         return (
             f"redis://:"
-            f"{self.REDIS_PASSWORD}@"
+            f"{quote(self.REDIS_PASSWORD, safe='')}@"
             f"{self.REDIS_HOST}:"
             f"{self.REDIS_PORT}/"
             f"{self.REDIS_TASKS_DATABASE}"
@@ -218,9 +220,12 @@ class PostgresConfig(BaseModel):
 
     @property
     def dsn_async(self) -> str:
+        # quote(safe="") because generated credentials routinely contain @ / % :
+        # and every URL parser downstream would silently misread the DSN.
         return (
             f"postgresql+asyncpg://"
-            f"{self.POSTGRES_USER}:{self.POSTGRES_PASSWORD}@"
+            f"{quote(self.POSTGRES_USER, safe='')}:"
+            f"{quote(self.POSTGRES_PASSWORD, safe='')}@"
             f"{self.POSTGRES_HOST}:{self.POSTGRES_PORT}/"
             f"{self.POSTGRES_DB}"
         )
@@ -229,7 +234,8 @@ class PostgresConfig(BaseModel):
     def dsn_sync(self) -> str:
         return (
             f"postgresql://"
-            f"{self.POSTGRES_USER}:{self.POSTGRES_PASSWORD}@"
+            f"{quote(self.POSTGRES_USER, safe='')}:"
+            f"{quote(self.POSTGRES_PASSWORD, safe='')}@"
             f"{self.POSTGRES_HOST}:{self.POSTGRES_PORT}/"
             f"{self.POSTGRES_DB}"
         )

--- a/src/user/auth/usecases/login.py
+++ b/src/user/auth/usecases/login.py
@@ -56,10 +56,10 @@ class LoginUserUseCase:
 
     Side effects:
     - Persists password hash updates when rehashing is required.
-    - Bumps the user:{id} cache namespace version - every write to the user row
-      does this unconditionally, including this one where the row is only
-      sometimes touched (the rehash branch), so no one has to remember an
-      exception to the rule.
+    - Bumps the user:{id} cache namespace version twice (pre- and post-commit) -
+      every write to the user row does this unconditionally, including this one
+      where the row is only sometimes touched (the rehash branch), so no one
+      has to remember an exception to the rule.
     - Token creation handles its own caching.
 
     Errors:

--- a/src/user/auth/usecases/login.py
+++ b/src/user/auth/usecases/login.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Annotated
 from uuid import uuid4
 
@@ -114,6 +115,9 @@ class LoginUserUseCase:
             session_id = str(uuid4())
             token_data = {"sub": str(user.id)}
             await self.cache.invalidate(user_cache_keys.namespace(user.id))
+            uow.add_after_commit_hook(
+                partial(self.cache.invalidate, user_cache_keys.namespace(user.id))
+            )
             await uow.commit()
             return TokenModel(
                 access_token=await create_access_token(

--- a/src/user/auth/usecases/reset_password_confirm.py
+++ b/src/user/auth/usecases/reset_password_confirm.py
@@ -54,7 +54,7 @@ class ResetPasswordConfirmUseCase:
     - Deletes the active reset-token key from Redis before commit to avoid
       partial-success password changes when Redis is unavailable.
     - Deletes user session keys from Redis before commit for the same reason.
-    - Bumps the user:{id} cache namespace version.
+    - Bumps the user:{id} cache namespace version twice (pre- and post-commit).
 
     Errors:
     - None (returns success=False for invalid tokens/users).

--- a/src/user/auth/usecases/reset_password_confirm.py
+++ b/src/user/auth/usecases/reset_password_confirm.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Annotated
 
 from fastapi import Depends
@@ -107,6 +108,9 @@ class ResetPasswordConfirmUseCase:
                 )
                 await invalidate_all_user_sessions(str(user.id), self.redis_client)
                 await self.cache.invalidate(user_cache_keys.namespace(user.id))
+                uow.add_after_commit_hook(
+                    partial(self.cache.invalidate, user_cache_keys.namespace(user.id))
+                )
                 await uow.commit()
                 logger.debug(
                     "[ResetPasswordConfirm] All user %s sessions invalidated.",

--- a/src/user/auth/usecases/verify_email.py
+++ b/src/user/auth/usecases/verify_email.py
@@ -49,7 +49,7 @@ class VerifyEmailUseCase:
     Side effects:
     - Updates user record in the database.
     - Deletes the active verification-token key from Redis after successful use.
-    - Bumps the user:{id} cache namespace version.
+    - Bumps the user:{id} cache namespace version twice (pre- and post-commit).
 
     Returns:
     - SuccessResponse: success=True if verified or already verified, False if the

--- a/src/user/auth/usecases/verify_email.py
+++ b/src/user/auth/usecases/verify_email.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Annotated
 
 from fastapi import Depends
@@ -101,6 +102,9 @@ class VerifyEmailUseCase:
                     email=normalized_email,
                 )
                 await self.cache.invalidate(user_cache_keys.namespace(user.id))
+                uow.add_after_commit_hook(
+                    partial(self.cache.invalidate, user_cache_keys.namespace(user.id))
+                )
                 await uow.commit()
                 await invalidate_active_one_time_token(
                     purpose="verification",

--- a/src/user/tasks.py
+++ b/src/user/tasks.py
@@ -28,19 +28,13 @@ async def cleanup_unverified_users(
     """
     Soft-delete users that never verified their account within the max age.
 
-    Does not bump the user:{id} cache namespace, for two independent reasons.
-    `batch_soft_delete` returns only an affected-row count, not the deleted ids,
-    so there is nothing to key an invalidation on without an extra query this bulk
-    path is not worth paying for - and no task can invalidate anyway: the cache is
-    initialized by the API process only (`on_cache_startup`, `src/main/lifespan.py`),
-    so `get_cache_instance()` raises inside a worker. A project that needs
-    worker-side invalidation builds a `RedisCache` on the worker's own Redis client
-    and calls `set_cache` at broker startup, then injects it through a provider in
-    `taskiq_worker/dependencies.py`.
-
-    A cached summary for one of these (already-unverified, inactive) accounts can
-    therefore serve a deleted user for up to its TTL - a bounded staleness window,
-    not a silent violation of the "every user-row write bumps the namespace" rule.
+    Does not bump the user:{id} cache namespace: `batch_soft_delete` returns
+    only an affected-row count, not the deleted ids, so there is nothing to key
+    an invalidation on without an extra query this bulk path is not worth
+    paying for. A cached summary for one of these (already-unverified,
+    inactive) accounts can therefore serve a deleted user for up to its TTL -
+    a bounded staleness window, not a silent violation of the "every user-row
+    write bumps the namespace" rule.
     """
     cutoff = get_utc_now() - UNVERIFIED_USER_MAX_AGE
     uow: ApplicationUnitOfWork = ApplicationUnitOfWork(session)

--- a/src/user/usecases/update_password.py
+++ b/src/user/usecases/update_password.py
@@ -54,7 +54,7 @@ class UpdateUserPasswordUseCase:
     - Updates user record in database.
     - Deletes all user session keys from Redis before commit to avoid
       partial-success password changes when Redis is unavailable.
-    - Bumps the user:{id} cache namespace version.
+    - Bumps the user:{id} cache namespace version twice (pre- and post-commit).
 
     Errors:
     - InstanceNotFoundException: if the user does not exist.

--- a/src/user/usecases/update_password.py
+++ b/src/user/usecases/update_password.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Annotated
 from uuid import UUID
 
@@ -103,6 +104,11 @@ class UpdateUserPasswordUseCase:
             await uow.flush()
             await invalidate_all_user_sessions(str(updated_user.id), self.redis_client)
             await self.cache.invalidate(user_cache_keys.namespace(updated_user.id))
+            uow.add_after_commit_hook(
+                partial(
+                    self.cache.invalidate, user_cache_keys.namespace(updated_user.id)
+                )
+            )
             await uow.commit()
             logger.debug(
                 "[UpdateUserPassword] %s password updated successfully.",

--- a/src/user/usecases/update_profile.py
+++ b/src/user/usecases/update_profile.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Annotated
 from uuid import UUID
 
@@ -35,11 +36,12 @@ class UpdateUserProfileUseCase:
     1) Apply the non-empty fields to the user row.
     2) Flush pending DB changes.
     3) Invalidate the user cache namespace.
-    4) Commit the transaction.
+    4) Commit the transaction; an after-commit hook invalidates the
+       namespace a second time.
 
     Side effects:
     - Updates the user record.
-    - Bumps the user:{id} cache namespace version.
+    - Bumps the user:{id} cache namespace version twice (pre- and post-commit).
 
     Errors:
     - InstanceNotFoundException: if the user does not exist.
@@ -65,10 +67,15 @@ class UpdateUserProfileUseCase:
             if not updated_user:
                 raise InstanceNotFoundException("User not found.")
             await uow.flush()
-            # Invalidation happens before commit on purpose: a bump that outlives a
-            # rolled-back transaction only costs a cold cache, while a bump skipped
-            # after a successful commit would serve stale data.
+            # Two bumps by design. Pre-commit covers the crash direction: a bump
+            # that outlives a rolled-back transaction only costs a cold cache.
+            # The post-commit bump closes the other race: a reader who re-cached
+            # the old row between the first bump and the commit would otherwise
+            # serve stale data until the TTL.
             await self.cache.invalidate(user_cache_keys.namespace(user_id))
+            uow.add_after_commit_hook(
+                partial(self.cache.invalidate, user_cache_keys.namespace(user_id))
+            )
             await uow.commit()
             logger.debug("[UpdateUserProfile] user %s profile updated.", user_id)
             return UserProfileViewModel.model_validate(updated_user)

--- a/src/user/usecases/update_profile.py
+++ b/src/user/usecases/update_profile.py
@@ -69,9 +69,14 @@ class UpdateUserProfileUseCase:
             await uow.flush()
             # Two bumps by design. Pre-commit covers the crash direction: a bump
             # that outlives a rolled-back transaction only costs a cold cache.
-            # The post-commit bump closes the other race: a reader who re-cached
+            # The post-commit bump narrows the other race: a reader who re-cached
             # the old row between the first bump and the commit would otherwise
-            # serve stale data until the TTL.
+            # serve stale data until the TTL. A residual window remains - a
+            # reader that read the old row before commit and writes its cache
+            # entry after the second bump still lands stale data in the current
+            # generation. Eliminating it needs version-conditional cache writes
+            # (capture the generation at the miss, write only if unchanged);
+            # accepted as bounded-by-TTL staleness instead of that complexity.
             await self.cache.invalidate(user_cache_keys.namespace(user_id))
             uow.add_after_commit_hook(
                 partial(self.cache.invalidate, user_cache_keys.namespace(user_id))

--- a/taskiq_worker/app.py
+++ b/taskiq_worker/app.py
@@ -6,19 +6,41 @@ invisible to the worker.
 
 from taskiq import TaskiqEvents, TaskiqState
 
+from src.core.cache.redis_cache import RedisCache
+from src.core.cache.runtime import reset_cache, set_cache
+from src.core.cache.serializer import JsonSerializer
 import src.core.email_service.tasks  # noqa: F401
 import src.core.outbox.tasks  # noqa: F401
+from src.main.config import config
 from src.main.sentry import init_sentry
 import src.user.auth.tasks  # noqa: F401
 import src.user.tasks  # noqa: F401
 from taskiq_worker.broker import broker
-from taskiq_worker.dependencies import close_tasks_redis_client
+from taskiq_worker.dependencies import _tasks_redis, close_tasks_redis_client
 
 init_sentry()
 
 
+@broker.on_event(TaskiqEvents.WORKER_STARTUP)
+async def on_worker_startup(_: TaskiqState) -> None:
+    # Mirror of the API's `on_cache_startup` (src/core/cache/lifecycle.py) so
+    # tasks can read and invalidate the same cache the API writes. Same prefix
+    # and TTLs are what make the keys shared; the client is the worker's own.
+    set_cache(
+        RedisCache(
+            redis_client=_tasks_redis(),
+            serializer=JsonSerializer(),
+            prefix=config.cache.CACHE_KEY_PREFIX,
+            default_ttl=config.cache.CACHE_DEFAULT_TTL,
+            version_ttl=config.cache.CACHE_VERSION_TTL,
+            enabled=config.cache.CACHE_ENABLED,
+        )
+    )
+
+
 @broker.on_event(TaskiqEvents.WORKER_SHUTDOWN)
 async def on_worker_shutdown(_: TaskiqState) -> None:
+    reset_cache()
     await close_tasks_redis_client()
 
 

--- a/taskiq_worker/app.py
+++ b/taskiq_worker/app.py
@@ -16,7 +16,10 @@ from src.main.sentry import init_sentry
 import src.user.auth.tasks  # noqa: F401
 import src.user.tasks  # noqa: F401
 from taskiq_worker.broker import broker
-from taskiq_worker.dependencies import _tasks_redis, close_tasks_redis_client
+from taskiq_worker.dependencies import (
+    close_tasks_redis_client,
+    get_tasks_redis_singleton,
+)
 
 init_sentry()
 
@@ -28,7 +31,7 @@ async def on_worker_startup(_: TaskiqState) -> None:
     # and TTLs are what make the keys shared; the client is the worker's own.
     set_cache(
         RedisCache(
-            redis_client=_tasks_redis(),
+            redis_client=get_tasks_redis_singleton(),
             serializer=JsonSerializer(),
             prefix=config.cache.CACHE_KEY_PREFIX,
             default_ttl=config.cache.CACHE_DEFAULT_TTL,

--- a/taskiq_worker/dependencies.py
+++ b/taskiq_worker/dependencies.py
@@ -17,7 +17,8 @@ async def get_tasks_session() -> AsyncGenerator[AsyncSession]:
 _tasks_redis_client: Redis | None = None
 
 
-def _tasks_redis() -> Redis:
+def get_tasks_redis_singleton() -> Redis:
+    """One Redis client per worker process; closed by the broker shutdown hook."""
     global _tasks_redis_client
     if _tasks_redis_client is None:
         _tasks_redis_client = create_redis_client(config.redis.dsn)
@@ -25,8 +26,7 @@ def _tasks_redis() -> Redis:
 
 
 async def get_tasks_redis_client() -> AsyncGenerator[Redis]:
-    # One client per worker process; closed by the broker shutdown hook.
-    yield _tasks_redis()
+    yield get_tasks_redis_singleton()
 
 
 async def close_tasks_redis_client() -> None:

--- a/tests/unit/src/core/database/test_database_repositories.py
+++ b/tests/unit/src/core/database/test_database_repositories.py
@@ -529,6 +529,19 @@ async def test_base_repository_update_updates_instance_and_commits() -> None:
 
 
 @pytest.mark.asyncio
+async def test_base_repository_update_rejects_unknown_fields() -> None:
+    # A typo in a data key must fail loudly instead of setattr silently
+    # attaching a plain attribute the flush then ignores.
+    repo = RepositoryModelRepository()
+    session = RepositorySession()
+
+    with pytest.raises(ValueError, match="nmae"):
+        await repo.update(session=session, data={"nmae": "new"}, id=1)
+
+    session.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_base_repository_update_returns_none_when_not_found() -> None:
     repo = RepositoryModelRepository()
     session = RepositorySession()

--- a/tests/unit/src/core/database/test_database_transactions.py
+++ b/tests/unit/src/core/database/test_database_transactions.py
@@ -8,7 +8,6 @@ from src.core.database.transactions import (
     _string_to_int64,
     advisory_xact_lock,
     maybe_begin,
-    safe_begin,
     try_advisory_xact_lock,
 )
 from tests.fakes.db import AsyncTransactionContext, FakeAsyncSession
@@ -112,27 +111,4 @@ async def test_maybe_begin_skips_when_already_in_transaction() -> None:
 
     assert session.in_transaction() is True
     assert session.begin_called == 0
-    assert session.begin_nested_called == 0
-
-
-@pytest.mark.asyncio
-async def test_safe_begin_uses_nested_transaction_when_active() -> None:
-    session = TrackingSession(in_transaction=True)
-
-    async with safe_begin(session):
-        assert session.in_transaction() is True
-
-    assert session.begin_called == 0
-    assert session.begin_nested_called == 1
-
-
-@pytest.mark.asyncio
-async def test_safe_begin_uses_regular_transaction_when_inactive() -> None:
-    session = TrackingSession(in_transaction=False)
-
-    async with safe_begin(session):
-        assert session.in_transaction() is True
-
-    assert session.in_transaction() is False
-    assert session.begin_called == 1
     assert session.begin_nested_called == 0

--- a/tests/unit/src/core/limiter/test_limiter_depends.py
+++ b/tests/unit/src/core/limiter/test_limiter_depends.py
@@ -92,12 +92,37 @@ async def test_rate_limiter_calls_callback_on_limit(
     response = Response()
 
     rate_key = await FastAPILimiter.identifier(request)
-    key = f"{FastAPILimiter.prefix}:{rate_key}:{sample_endpoint.__name__}"
+    key = (
+        f"{FastAPILimiter.prefix}:{rate_key}:"
+        f"{sample_endpoint.__module__}.{sample_endpoint.__qualname__}"
+    )
     fake_redis.set_evalsha_result(key, 1000)
 
     await limiter(request, response)
 
     callback.assert_awaited_once_with(request, response, 1000)
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_key_qualifies_endpoint_by_module(
+    limiter_state: None,
+    fake_redis: InMemoryRedis,
+) -> None:
+    # Two modules can both expose an endpoint named `create` - a bare __name__
+    # would silently merge their buckets into one shared limit.
+    FastAPILimiter.redis = fake_redis
+    FastAPILimiter.lua_sha = await fake_redis.script_load(FastAPILimiter.lua_script)
+    limiter = RateLimiter(times=1, seconds=1, callback=AsyncMock())
+    request = build_request(path="/test", endpoint=sample_endpoint)
+
+    await limiter(request, Response())
+
+    rate_key = await FastAPILimiter.identifier(request)
+    expected_key = (
+        f"{FastAPILimiter.prefix}:{rate_key}:"
+        f"{sample_endpoint.__module__}.{sample_endpoint.__qualname__}"
+    )
+    assert fake_redis.evalsha_keys[-1] == expected_key
 
 
 @pytest.mark.asyncio
@@ -220,9 +245,10 @@ async def test_rate_limiter_fallback_evicts_oldest_window_when_capacity_reached(
 
     assert len(RateLimiter._fallback_windows) == 2
     fallback_keys = set(RateLimiter._fallback_windows)
-    assert "limiter:alpha:sample_endpoint" not in fallback_keys
-    assert "limiter:beta:sample_endpoint" in fallback_keys
-    assert "limiter:gamma:sample_endpoint" in fallback_keys
+    endpoint_name = f"{sample_endpoint.__module__}.{sample_endpoint.__qualname__}"
+    assert f"limiter:alpha:{endpoint_name}" not in fallback_keys
+    assert f"limiter:beta:{endpoint_name}" in fallback_keys
+    assert f"limiter:gamma:{endpoint_name}" in fallback_keys
     warning_mock.assert_called_once()
     assert "In-memory fallback capacity reached" in warning_mock.call_args.args[0]
     callback.assert_not_awaited()

--- a/tests/unit/src/core/limiter/test_limiter_identifier.py
+++ b/tests/unit/src/core/limiter/test_limiter_identifier.py
@@ -69,4 +69,5 @@ async def test_unique_forwarded_for_per_request_shares_one_limit_window(
         )
         await limiter(request, response)
 
-    assert fake_redis.evalsha_keys == ["limiter:127.0.0.1:/test:sample_endpoint"] * 3
+    endpoint_name = f"{sample_endpoint.__module__}.{sample_endpoint.__qualname__}"
+    assert fake_redis.evalsha_keys == [f"limiter:127.0.0.1:/test:{endpoint_name}"] * 3

--- a/tests/unit/src/core/outbox/test_dispatcher.py
+++ b/tests/unit/src/core/outbox/test_dispatcher.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock
-from uuid import UUID
+from uuid import UUID, uuid4
 
+import pytest
 from taskiq import InMemoryBroker
 
 from src.core.outbox.dispatcher import TaskDispatcher
@@ -84,6 +85,20 @@ async def test_publish_hook_marks_row_published() -> None:
     assert (
         dispatcher._outbox_repository.mark_published.await_args.args[1] == row.id
     )  # noqa: SLF001
+
+
+async def test_enqueue_transactional_rejects_non_json_arguments() -> None:
+    # Arguments live in a JSONB outbox row: a UUID would raise deep inside the
+    # INSERT flush - the guard fails at the call site and names the task.
+    _broker, _calls, probe = make_broker_and_probe()
+    dispatcher = TaskDispatcher(session_factory=FakeSessionFactory())
+    uow, outbox_repo, _row = make_uow_with_outbox()
+
+    async with uow:
+        with pytest.raises(TypeError, match="outbox_probe"):
+            await dispatcher.enqueue_transactional(uow, probe, uuid4())
+        outbox_repo.create.assert_not_awaited()
+        await uow.rollback()
 
 
 async def test_rollback_discards_publish() -> None:

--- a/tests/unit/src/core/outbox/test_dispatcher.py
+++ b/tests/unit/src/core/outbox/test_dispatcher.py
@@ -1,3 +1,4 @@
+import enum
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 
@@ -87,6 +88,10 @@ async def test_publish_hook_marks_row_published() -> None:
     )  # noqa: SLF001
 
 
+class _Color(enum.StrEnum):
+    RED = "red"
+
+
 @pytest.mark.parametrize(
     "bad_args,bad_kwargs",
     [
@@ -94,6 +99,8 @@ async def test_publish_hook_marks_row_published() -> None:
         ((float("nan"),), {}),  # dumps would emit the invalid-JSON token NaN
         ((), {"mapping": {1: "x"}}),  # int key coerced to "1" on republish
         (((1, 2),), {}),  # nested tuple becomes a list on republish
+        ((_Color.RED,), {}),  # StrEnum == its str, but republish sends plain str
+        ((), {"mapping": {_Color.RED: "x"}}),  # enum dict key decays the same way
     ],
 )
 async def test_enqueue_transactional_rejects_non_json_arguments(

--- a/tests/unit/src/core/outbox/test_dispatcher.py
+++ b/tests/unit/src/core/outbox/test_dispatcher.py
@@ -87,16 +87,28 @@ async def test_publish_hook_marks_row_published() -> None:
     )  # noqa: SLF001
 
 
-async def test_enqueue_transactional_rejects_non_json_arguments() -> None:
+@pytest.mark.parametrize(
+    "bad_args,bad_kwargs",
+    [
+        ((uuid4(),), {}),  # not serializable at all
+        ((float("nan"),), {}),  # dumps would emit the invalid-JSON token NaN
+        ((), {"mapping": {1: "x"}}),  # int key coerced to "1" on republish
+        (((1, 2),), {}),  # nested tuple becomes a list on republish
+    ],
+)
+async def test_enqueue_transactional_rejects_non_json_arguments(
+    bad_args: tuple, bad_kwargs: dict
+) -> None:
     # Arguments live in a JSONB outbox row: a UUID would raise deep inside the
-    # INSERT flush - the guard fails at the call site and names the task.
+    # INSERT flush, and coercible values would make the sweeper republish a
+    # different payload - the guard fails at the call site and names the task.
     _broker, _calls, probe = make_broker_and_probe()
     dispatcher = TaskDispatcher(session_factory=FakeSessionFactory())
     uow, outbox_repo, _row = make_uow_with_outbox()
 
     async with uow:
         with pytest.raises(TypeError, match="outbox_probe"):
-            await dispatcher.enqueue_transactional(uow, probe, uuid4())
+            await dispatcher.enqueue_transactional(uow, probe, *bad_args, **bad_kwargs)
         outbox_repo.create.assert_not_awaited()
         await uow.rollback()
 

--- a/tests/unit/src/main/test_config.py
+++ b/tests/unit/src/main/test_config.py
@@ -323,6 +323,21 @@ def test_postgres_dsn_escapes_special_characters_in_credentials() -> None:
         assert url.database == "app"
 
 
+@pytest.mark.parametrize("bad_name", ["app/db", "app?x", "app#1", "a@b", "a:b", "a b"])
+def test_postgres_rejects_url_breaking_database_name(bad_name: str) -> None:
+    # make_url does not decode the database path segment, so such a name can
+    # be neither passed raw (misparsed) nor percent-encoded (renamed).
+    with pytest.raises(ValidationError, match="POSTGRES_DB"):
+        PostgresConfig(
+            DB_ECHO=False,
+            POSTGRES_USER="app",
+            POSTGRES_PASSWORD="secret",
+            POSTGRES_HOST="db-host",
+            POSTGRES_PORT=5432,
+            POSTGRES_DB=bad_name,
+        )
+
+
 def test_postgres_pool_sizes_default_and_validate() -> None:
     postgres_config = PostgresConfig(
         DB_ECHO=False,

--- a/tests/unit/src/main/test_config.py
+++ b/tests/unit/src/main/test_config.py
@@ -1,10 +1,14 @@
 from pydantic import ValidationError
 import pytest
+from redis.connection import parse_url
+from sqlalchemy.engine import make_url
 
 from src.main.config import (
     AppConfig,
     CacheConfig,
     JWTConfig,
+    PostgresConfig,
+    RedisConfig,
     S3Config,
 )
 
@@ -285,10 +289,6 @@ def test_s3_enabled_requires_credentials() -> None:
 
 
 def test_redis_dsn_escapes_special_characters_in_password() -> None:
-    from redis.connection import parse_url
-
-    from src.main.config import RedisConfig
-
     raw_password = "p@ss/word%:x"
     redis_config = RedisConfig(
         REDIS_HOST="redis-host",
@@ -305,10 +305,6 @@ def test_redis_dsn_escapes_special_characters_in_password() -> None:
 
 
 def test_postgres_dsn_escapes_special_characters_in_credentials() -> None:
-    from sqlalchemy.engine import make_url
-
-    from src.main.config import PostgresConfig
-
     raw_password = "p@ss/word%:x"
     postgres_config = PostgresConfig(
         DB_ECHO=False,
@@ -325,3 +321,30 @@ def test_postgres_dsn_escapes_special_characters_in_credentials() -> None:
         assert url.password == raw_password
         assert url.host == "db-host"
         assert url.database == "app"
+
+
+def test_postgres_pool_sizes_default_and_validate() -> None:
+    postgres_config = PostgresConfig(
+        DB_ECHO=False,
+        POSTGRES_USER="app",
+        POSTGRES_PASSWORD="secret",
+        POSTGRES_HOST="db-host",
+        POSTGRES_PORT=5432,
+        POSTGRES_DB="app",
+    )
+
+    assert postgres_config.DB_POOL_SIZE == 5
+    assert postgres_config.DB_MAX_OVERFLOW == 2
+    assert postgres_config.DB_TASKS_POOL_SIZE == 5
+    assert postgres_config.DB_TASKS_MAX_OVERFLOW == 15
+
+    with pytest.raises(ValidationError):
+        PostgresConfig(
+            DB_ECHO=False,
+            POSTGRES_USER="app",
+            POSTGRES_PASSWORD="secret",
+            POSTGRES_HOST="db-host",
+            POSTGRES_PORT=5432,
+            POSTGRES_DB="app",
+            DB_POOL_SIZE=0,
+        )

--- a/tests/unit/src/main/test_config.py
+++ b/tests/unit/src/main/test_config.py
@@ -323,10 +323,9 @@ def test_postgres_dsn_escapes_special_characters_in_credentials() -> None:
         assert url.database == "app"
 
 
-@pytest.mark.parametrize("bad_name", ["app/db", "app?x", "app#1", "a@b", "a:b", "a b"])
-def test_postgres_rejects_url_breaking_database_name(bad_name: str) -> None:
-    # make_url does not decode the database path segment, so such a name can
-    # be neither passed raw (misparsed) nor percent-encoded (renamed).
+def test_postgres_rejects_question_mark_in_database_name() -> None:
+    # make_url truncates the database at '?' (query string) and does not decode
+    # the path segment, so the name can be neither passed raw nor encoded.
     with pytest.raises(ValidationError, match="POSTGRES_DB"):
         PostgresConfig(
             DB_ECHO=False,
@@ -334,8 +333,23 @@ def test_postgres_rejects_url_breaking_database_name(bad_name: str) -> None:
             POSTGRES_PASSWORD="secret",
             POSTGRES_HOST="db-host",
             POSTGRES_PORT=5432,
-            POSTGRES_DB=bad_name,
+            POSTGRES_DB="app?x",
         )
+
+
+@pytest.mark.parametrize("odd_name", ["app/db", "app#1", "a@b", "a:b", "a b"])
+def test_postgres_allows_database_names_make_url_preserves(odd_name: str) -> None:
+    postgres_config = PostgresConfig(
+        DB_ECHO=False,
+        POSTGRES_USER="app",
+        POSTGRES_PASSWORD="secret",
+        POSTGRES_HOST="db-host",
+        POSTGRES_PORT=5432,
+        POSTGRES_DB=odd_name,
+    )
+
+    for dsn in (postgres_config.dsn_async, postgres_config.dsn_sync):
+        assert make_url(dsn).database == odd_name
 
 
 def test_postgres_pool_sizes_default_and_validate() -> None:

--- a/tests/unit/src/main/test_config.py
+++ b/tests/unit/src/main/test_config.py
@@ -282,3 +282,46 @@ def test_s3_disabled_needs_no_credentials() -> None:
 def test_s3_enabled_requires_credentials() -> None:
     with pytest.raises(ValidationError, match="S3_ENABLED=true requires"):
         S3Config(S3_ENABLED=True, S3_BUCKET_NAME="b")  # missing the rest
+
+
+def test_redis_dsn_escapes_special_characters_in_password() -> None:
+    from redis.connection import parse_url
+
+    from src.main.config import RedisConfig
+
+    raw_password = "p@ss/word%:x"
+    redis_config = RedisConfig(
+        REDIS_HOST="redis-host",
+        REDIS_PORT=6379,
+        REDIS_PASSWORD=raw_password,
+        REDIS_DATABASE="0",
+    )
+
+    parsed = parse_url(redis_config.dsn)
+
+    assert parsed["password"] == raw_password
+    assert parsed["host"] == "redis-host"
+    assert parsed["db"] == 0
+
+
+def test_postgres_dsn_escapes_special_characters_in_credentials() -> None:
+    from sqlalchemy.engine import make_url
+
+    from src.main.config import PostgresConfig
+
+    raw_password = "p@ss/word%:x"
+    postgres_config = PostgresConfig(
+        DB_ECHO=False,
+        POSTGRES_USER="app:user",
+        POSTGRES_PASSWORD=raw_password,
+        POSTGRES_HOST="db-host",
+        POSTGRES_PORT=5432,
+        POSTGRES_DB="app",
+    )
+
+    for dsn in (postgres_config.dsn_async, postgres_config.dsn_sync):
+        url = make_url(dsn)
+        assert url.username == "app:user"
+        assert url.password == raw_password
+        assert url.host == "db-host"
+        assert url.database == "app"

--- a/tests/unit/src/user/auth/usecases/test_auth_usecases_stage1.py
+++ b/tests/unit/src/user/auth/usecases/test_auth_usecases_stage1.py
@@ -468,6 +468,8 @@ async def test_reset_password_confirm_success(
     )
     cache_key = user_cache_keys.summary(user.id)
     await cache.set(cache_key, {"name": "stale"}, ttl=60)
+    cache_invalidate_spy = AsyncMock(wraps=cache.invalidate)
+    cache.invalidate = cache_invalidate_spy  # type: ignore[method-assign]
 
     use_case = ResetPasswordConfirmUseCase(
         uow=uow, redis_client=fake_redis, cache=cache
@@ -481,6 +483,8 @@ async def test_reset_password_confirm_success(
     uow.commit.assert_awaited_once()
     uow.flush.assert_awaited_once()
     assert await cache.get(cache_key) is None
+    # Pre-commit bump plus the after-commit hook's second bump.
+    assert cache_invalidate_spy.await_count == 2
     assert (
         await fake_redis.exists(
             auth_redis_keys.one_time_token("reset_password", user.email)
@@ -699,6 +703,8 @@ async def test_verify_email_usecase_success(
     use_case = VerifyEmailUseCase(uow=uow, redis_client=fake_redis, cache=cache)
     cache_key = user_cache_keys.summary(user.id)
     await cache.set(cache_key, {"name": "stale"}, ttl=60)
+    cache_invalidate_spy = AsyncMock(wraps=cache.invalidate)
+    cache.invalidate = cache_invalidate_spy  # type: ignore[method-assign]
 
     token = await build_verification_token({"email": user.email}, fake_redis)
 
@@ -707,6 +713,8 @@ async def test_verify_email_usecase_success(
     assert result == SuccessResponse(success=True)
     uow.commit.assert_awaited_once()
     uow.flush.assert_not_awaited()
+    # Pre-commit bump plus the after-commit hook's second bump.
+    assert cache_invalidate_spy.await_count == 2
     assert (
         await fake_redis.exists(
             auth_redis_keys.one_time_token("verification", user.email)

--- a/tests/unit/src/user/auth/usecases/test_login_usecase_rehash.py
+++ b/tests/unit/src/user/auth/usecases/test_login_usecase_rehash.py
@@ -60,6 +60,8 @@ async def test_login_rehashes_password_when_needed(
     monkeypatch.setattr(login_usecase, "create_refresh_token", refresh_mock)
     cache_key = user_cache_keys.summary(user.id)
     await cache.set(cache_key, {"name": "stale"}, ttl=60)
+    cache_invalidate_spy = AsyncMock(wraps=cache.invalidate)
+    cache.invalidate = cache_invalidate_spy  # type: ignore[method-assign]
 
     use_case = LoginUserUseCase(uow=uow, redis_client=fake_redis, cache=cache)
     result = await use_case.execute(
@@ -79,6 +81,8 @@ async def test_login_rehashes_password_when_needed(
     uow.flush.assert_not_awaited()
     uow.commit.assert_awaited_once()
     assert await cache.get(cache_key) is None
+    # Pre-commit bump plus the after-commit hook's second bump.
+    assert cache_invalidate_spy.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/src/user/usecases/test_update_password_usecase.py
+++ b/tests/unit/src/user/usecases/test_update_password_usecase.py
@@ -169,6 +169,8 @@ async def test_update_password_success(
     )
     cache_key = user_cache_keys.summary(user.id)
     await cache.set(cache_key, {"name": "stale"}, ttl=60)
+    cache_invalidate_spy = AsyncMock(wraps=cache.invalidate)
+    cache.invalidate = cache_invalidate_spy  # type: ignore[method-assign]
 
     use_case = UpdateUserPasswordUseCase(uow=uow, redis_client=fake_redis, cache=cache)
     result = await use_case.execute(data=change_password_data(), user_id=user.id)
@@ -178,6 +180,8 @@ async def test_update_password_success(
     uow.flush.assert_awaited_once()
     invalidate_mock.assert_awaited_once_with(str(user.id), fake_redis)
     assert await cache.get(cache_key) is None
+    # Pre-commit bump plus the after-commit hook's second bump.
+    assert cache_invalidate_spy.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/src/user/usecases/test_update_profile_usecase.py
+++ b/tests/unit/src/user/usecases/test_update_profile_usecase.py
@@ -50,21 +50,37 @@ async def test_profile_update_bumps_cache_before_and_after_commit(
 ) -> None:
     # Pre-commit bump covers the crash direction; the post-commit bump closes
     # the race where a reader re-caches stale data between bump and commit.
+    # The interleaving matters: two bumps both before commit would silently
+    # reintroduce that race, so the test records the order of events.
     user = build_user()
     users_repo = FakeUsersRepository(updated_user=user)
     uow = build_uow(fake_session, users_repo)
-    invalidate_spy = AsyncMock(wraps=cache.invalidate)
-    cache.invalidate = invalidate_spy  # type: ignore[method-assign]
+    namespace = f"user:{user.id}"
+    events: list[str] = []
+    original_invalidate = cache.invalidate
+
+    async def recording_invalidate(invalidated_namespace: str) -> None:
+        assert invalidated_namespace == namespace
+        events.append("invalidate")
+        await original_invalidate(invalidated_namespace)
+
+    cache.invalidate = recording_invalidate  # type: ignore[method-assign]
+    original_commit_effect = uow.commit.side_effect
+
+    async def recording_commit() -> None:
+        events.append("commit")
+        # The fake runs after-commit hooks inside this call, mirroring the
+        # real UoW: the hook's invalidate lands after the "commit" marker.
+        await original_commit_effect()
+
+    uow.commit = AsyncMock(side_effect=recording_commit)
     use_case = UpdateUserProfileUseCase(uow=uow, cache=cache)
 
     await use_case.execute(
         data=UserProfileUpdateModel(first_name="Grace"), user_id=user.id
     )
 
-    namespace = f"user:{user.id}"
-    assert invalidate_spy.await_count == 2
-    for call in invalidate_spy.await_args_list:
-        assert call.args == (namespace,)
+    assert events == ["invalidate", "commit", "invalidate"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/src/user/usecases/test_update_profile_usecase.py
+++ b/tests/unit/src/user/usecases/test_update_profile_usecase.py
@@ -45,6 +45,29 @@ async def test_profile_update_bumps_cache_namespace(
 
 
 @pytest.mark.asyncio
+async def test_profile_update_bumps_cache_before_and_after_commit(
+    fake_session: FakeAsyncSession, cache: InMemoryCache
+) -> None:
+    # Pre-commit bump covers the crash direction; the post-commit bump closes
+    # the race where a reader re-caches stale data between bump and commit.
+    user = build_user()
+    users_repo = FakeUsersRepository(updated_user=user)
+    uow = build_uow(fake_session, users_repo)
+    invalidate_spy = AsyncMock(wraps=cache.invalidate)
+    cache.invalidate = invalidate_spy  # type: ignore[method-assign]
+    use_case = UpdateUserProfileUseCase(uow=uow, cache=cache)
+
+    await use_case.execute(
+        data=UserProfileUpdateModel(first_name="Grace"), user_id=user.id
+    )
+
+    namespace = f"user:{user.id}"
+    assert invalidate_spy.await_count == 2
+    for call in invalidate_spy.await_args_list:
+        assert call.args == (namespace,)
+
+
+@pytest.mark.asyncio
 async def test_missing_user_raises_not_found(
     fake_session: FakeAsyncSession, cache: InMemoryCache
 ) -> None:

--- a/tests/unit/taskiq_worker/test_app.py
+++ b/tests/unit/taskiq_worker/test_app.py
@@ -1,11 +1,19 @@
+from collections.abc import Iterator
 import json
 import os
 import subprocess
 import sys
 
+import pytest
+from taskiq import TaskiqState
 from taskiq.schedule_sources import LabelScheduleSource
 
+from src.core.cache.redis_cache import RedisCache
+from src.core.cache.runtime import get_cache_instance, reset_cache
+from src.main.config import config
+import taskiq_worker.app as worker_app
 from taskiq_worker.scheduler import scheduler
+from tests.fakes.redis import InMemoryRedis
 
 EXPECTED_TASKS = {
     "cleanup_unverified_users",
@@ -53,3 +61,40 @@ def test_app_registers_every_task() -> None:
 
 def test_scheduler_reads_labels_from_broker() -> None:
     assert any(isinstance(source, LabelScheduleSource) for source in scheduler.sources)
+
+
+@pytest.fixture
+def clean_cache_singleton() -> Iterator[None]:
+    reset_cache()
+    yield
+    reset_cache()
+
+
+async def test_worker_startup_wires_the_shared_cache(
+    clean_cache_singleton: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_redis = InMemoryRedis()
+    monkeypatch.setattr(worker_app, "get_tasks_redis_singleton", lambda: fake_redis)
+
+    await worker_app.on_worker_startup(TaskiqState())
+
+    cache = get_cache_instance()
+    assert isinstance(cache, RedisCache)
+    # Same prefix as the API's on_cache_startup - that is what makes the keys
+    # shared between the two processes.
+    assert cache._prefix == config.cache.CACHE_KEY_PREFIX  # noqa: SLF001
+
+
+async def test_worker_shutdown_resets_the_cache_singleton(
+    clean_cache_singleton: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_redis = InMemoryRedis()
+    monkeypatch.setattr(worker_app, "get_tasks_redis_singleton", lambda: fake_redis)
+    await worker_app.on_worker_startup(TaskiqState())
+
+    await worker_app.on_worker_shutdown(TaskiqState())
+
+    with pytest.raises(RuntimeError, match="Cache is not initialized"):
+        get_cache_instance()


### PR DESCRIPTION
Fixes latent traps surfaced by the architectural review.

- Config: URL-escape Redis/Postgres credentials in DSNs; fail fast on a database name a URL cannot represent; DB pool sizes become settings (DB_POOL_SIZE, DB_MAX_OVERFLOW, DB_TASKS_POOL_SIZE, DB_TASKS_MAX_OVERFLOW).
- Repositories: update() rejects unknown data keys instead of silently attaching plain attributes the flush ignores.
- Outbox: enqueue_transactional fails loudly on non-JSON and non-round-trippable arguments (NaN, int dict keys, nested tuples) - the sweeper republish must send the same payload as the inline publish.
- Rate limiter: bucket keys use endpoint module.qualname, so same-named endpoints in different modules no longer share a limit.
- Cache: post-commit second namespace bump via an after-commit hook in the five user-write usecases, closing the stale-recache race; worker process now initializes the shared cache singleton at startup.
- Dropped unused safe_begin; UoW abstract exit docstring states the explicit-commit contract.

Testing: make lint, 903 unit tests, 18 integration tests pass.