### PR TITLE
chore(ci): keep dependabot off python minor and major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,15 @@ updates:
     commit-message:
       prefix: "Chore:"
       include: "scope"
+    # The Python minor line is a deliberate choice shared with the CI matrix
+    # (.github/workflows/*.yml pin python-version) and the wheels available for
+    # the locked dependencies, so it moves by hand in one commit, never by a bot.
+    # Base-image rebuilds inside the line (security patches) still come through.
+    ignore:
+      - dependency-name: "python"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     groups:
       docker-images:
         patterns:


### PR DESCRIPTION
Dependabot opened #175 to move the app image from `python:3.13-slim-bookworm` to `3.14-slim-bookworm`. The Python minor line is not a bot decision here: CI pins the same version in every `setup-python` step and the requirement lockfiles are resolved against wheels built for it, so a PR that bumps the Dockerfile alone leaves the two out of sync.

Adds an `ignore` entry for the `python` dependency in the `/infra/docker` ecosystem covering `version-update:semver-minor` and `version-update:semver-major`. Patch-level rebuilds of the base image still come through, so security updates inside the 3.13 line are unaffected. Moving to 3.14 stays a manual commit that touches the Dockerfiles and the CI pins together; no config change is needed then, since the cap follows whatever line the Dockerfiles are on.

Only the `/infra/docker` block needs it: the `github-actions` ecosystem updates action refs, not the `python-version` input.

Testing: config parsed and the ignore block verified to land on the `/infra/docker` update only; pre-commit yaml check passed.

Rollout: #175 must be closed by hand, the ignore rule only applies to new Dependabot runs.