### PR TITLE
chore(ci): move dependency updates to a monthly cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/infra/requirements"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "06:00"
       timezone: "UTC"
     open-pull-requests-limit: 5
@@ -21,8 +20,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "06:00"
       timezone: "UTC"
     open-pull-requests-limit: 5
@@ -38,8 +36,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/infra/postgres"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "06:00"
       timezone: "UTC"
     open-pull-requests-limit: 5
@@ -55,8 +52,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/infra/docker"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "06:00"
       timezone: "UTC"
     open-pull-requests-limit: 5
@@ -81,8 +77,7 @@ updates:
   - package-ecosystem: "docker-compose"
     directory: "/infra"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "06:00"
       timezone: "UTC"
     open-pull-requests-limit: 5

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -2,7 +2,7 @@ name: Pre-commit Autoupdate
 
 on:
   schedule:
-    - cron: "20 6 * * 1"
+    - cron: "20 6 1 * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -2,7 +2,7 @@ name: Pre-commit Autoupdate
 
 on:
   schedule:
-    - cron: "20 6 1 * *"
+    - cron: "20 6 3 * *"
   workflow_dispatch:
 
 permissions:

--- a/docs/readme/contributing.md
+++ b/docs/readme/contributing.md
@@ -35,7 +35,7 @@
 - Releases publish images only. Deployment still follows `main`; to run a release image, deploy it explicitly with `make deploy-image APP_IMAGE=ghcr.io/<owner>/<repo>:vX.Y.Z`.
 
 ### Pre-commit Autoupdate (`.github/workflows/pre-commit-autoupdate.yml`)
-- Runs monthly (1st of the month, `06:20 UTC`) and can be triggered manually (`workflow_dispatch`).
+- Runs monthly (3rd of the month, `06:20 UTC`) and can be triggered manually (`workflow_dispatch`).
 - Updates hook revisions in `.pre-commit-config.yaml` via `pre-commit autoupdate`.
 - Syncs `mypy.additional_dependencies` in `.pre-commit-config.yaml` from pinned versions in `infra/requirements/dev.txt` via `scripts/sync_precommit_mypy_deps.py`.
 - Validates resulting config with `pre-commit validate-config`.

--- a/docs/readme/contributing.md
+++ b/docs/readme/contributing.md
@@ -35,7 +35,7 @@
 - Releases publish images only. Deployment still follows `main`; to run a release image, deploy it explicitly with `make deploy-image APP_IMAGE=ghcr.io/<owner>/<repo>:vX.Y.Z`.
 
 ### Pre-commit Autoupdate (`.github/workflows/pre-commit-autoupdate.yml`)
-- Runs weekly (Monday, `06:20 UTC`) and can be triggered manually (`workflow_dispatch`).
+- Runs monthly (1st of the month, `06:20 UTC`) and can be triggered manually (`workflow_dispatch`).
 - Updates hook revisions in `.pre-commit-config.yaml` via `pre-commit autoupdate`.
 - Syncs `mypy.additional_dependencies` in `.pre-commit-config.yaml` from pinned versions in `infra/requirements/dev.txt` via `scripts/sync_precommit_mypy_deps.py`.
 - Validates resulting config with `pre-commit validate-config`.


### PR DESCRIPTION
Dependency update automation ran weekly, which is more churn than a template needs: five Dependabot ecosystems opened grouped PRs every Monday, and the pre-commit autoupdate workflow opened one more the same morning.

What changed:
- `.github/dependabot.yml` — all five ecosystems (pip, github-actions, docker x2, docker-compose) switch from `interval: weekly` + `day: monday` to `interval: monthly`. Dependabot runs monthly jobs on the 1st, keeping the existing `06:00 UTC` time; `day` is only meaningful for a weekly interval, so it is dropped.
- `.github/workflows/pre-commit-autoupdate.yml` — cron `20 6 * * 1` becomes `20 6 3 * *` (3rd of the month, `06:20 UTC`), two days clear of the Dependabot batch. `workflow_dispatch` still allows an on-demand run.
- `docs/readme/contributing.md` — the autoupdate cadence line follows.

Grouping, PR limits, labels, commit prefixes and the Python major/minor ignore rule are untouched.

Testing: both YAML files parse; pre-commit hooks pass on the changed files. Scheduling itself is only observable after merge on `main`.

No config or env changes.