### PR TITLE
docs: make docstrings state the contract, not the code

### DIFF
--- a/scripts/create_admin.py
+++ b/scripts/create_admin.py
@@ -62,37 +62,16 @@ async def ensure_admin(
     phone_number: str,
 ) -> None:
     """
-    Create the first admin user, or promote an existing account to admin.
+    Create the first admin account, or promote an existing one.
 
-    Inputs:
-    - uow: unit of work wrapping the session to operate on.
-    - email, password: credentials for the account.
-    - first_name, last_name, username, phone_number: profile fields used only
-      when a new user is created.
+    An account that already carries this email is forced to role=ADMIN, active
+    and verified with its stored password hash left alone, so re-running the
+    script never resets someone's password. The profile arguments therefore
+    apply to a newly created account only.
 
-    Validations:
-    - email and password are validated with the same rules as self-registration
-      (EmailStr plus normalization, and the strong-password pattern), checked
-      before any repository call.
-
-    Workflow:
-    1) Validate and normalize the email; validate the password strength.
-    2) Look up an existing, non-deleted user by email.
-    3) If found, force role=ADMIN and is_active/is_verified=True, leaving the
-       stored password hash untouched.
-    4) Otherwise create a new user with a freshly hashed password, already
-       admin, active and verified.
-    5) Commit the transaction.
-
-    Side effects:
-    - Creates or updates one row in the users table.
-
-    Errors:
-    - pydantic.ValidationError: the email is not a valid address, or the
-      password does not meet the strength rules.
-
-    Returns:
-    - None.
+    Email and password are validated with the same rules as self-registration,
+    before any repository call: an address that login would reject must not
+    become an account nobody can sign into.
     """
     credentials = _AdminCredentialsModel(email=email, password=password)
     normalized_email = credentials.email

--- a/scripts/sync_precommit_mypy_deps.py
+++ b/scripts/sync_precommit_mypy_deps.py
@@ -35,11 +35,8 @@ def parse_requirements_versions(requirements_text: str) -> dict[str, str]:
 
 
 def extract_dep_package(dep_spec: str) -> tuple[str, str]:
-    """
-    Returns:
-    - package token as written in pre-commit config (can include extras)
-    - normalized base package name for requirements lookup
-    """
+    """Split a dependency into the token as written in the pre-commit config,
+    extras included, and the normalized name the lockfile is keyed by."""
     dep_spec = dep_spec.strip()
     if not dep_spec:
         return "", ""

--- a/src/core/auth/credentials.py
+++ b/src/core/auth/credentials.py
@@ -63,18 +63,14 @@ async def verify_jti(token: str, redis_client: Redis, realm: AuthRealm) -> JWTPa
     """
     Verify JWT claims and compare the token JTI against Redis state.
 
-    Args:
-        token: The JWT token, with or without the `Bearer ` prefix.
-        redis_client: Redis client used to validate active and used keys.
-        realm: The auth contour whose secret and key namespace own the token.
+    A valid signature is not enough: the jti must still be the one Redis holds
+    for that session, so a token that was rotated out or revoked fails here
+    while verifying cryptographically. Expiry raises TokenExpiredError, whose
+    own error code lets a client tell "refresh and retry" apart from "this
+    token is not ours"; everything else answers the generic 401.
 
-    Returns:
-        JWTPayload: The verified JWT payload.
-
-    Raises:
-        TokenExpiredError: If the token has expired.
-        UnauthorizedException: If the token is malformed, has an invalid
-            structure, was reused, or no longer matches the active Redis entry.
+    The `Bearer ` prefix is optional - callers hand over whatever the transport
+    gave them, header or cookie.
     """
     if isinstance(token, str) and token.lower().startswith("bearer "):
         token = token[7:].strip()
@@ -142,11 +138,8 @@ async def decode_logout_identity(
     session it can neither use nor clear. The signature is still verified -
     only the `exp` claim is relaxed - so a forged token identifies nothing.
 
-    Returns:
-        SessionIdentity: The subject and session named by a signature-valid
-            access token.
-        None: If no token was given, or it is forged, malformed or not an
-            access token.
+    Answers None for every unusable case alike: no token, a forged or malformed
+    one, or one that is not an access token.
     """
     if not token:
         return None

--- a/src/core/auth/one_time_tokens.py
+++ b/src/core/auth/one_time_tokens.py
@@ -27,9 +27,6 @@ async def issue_one_time_token(
 
     The identifier arrives normalized: the core cannot know whether it is an
     email, a phone number or a login, so it neither lowercases nor validates it.
-
-    Returns:
-        str: the encoded token, ready to be embedded in a link.
     """
     token, jti = await issue_token(
         sub=identifier,
@@ -61,9 +58,6 @@ async def decode_one_time_token(
     Callers keep their own jwt.ExpiredSignatureError / jwt.InvalidTokenError
     ladders: this raises only for what can be decided after a successful
     decode - a missing identifier, a mode mismatch, or a superseded challenge.
-
-    Returns:
-        str: the identifier the token was issued for.
     """
     payload = jwt.decode(
         token,

--- a/src/core/auth/redis_scripts.py
+++ b/src/core/auth/redis_scripts.py
@@ -1,9 +1,8 @@
 """
-Redis Lua scripts for token management.
-
-This module contains Lua scripts for atomic operations on tokens in Redis.
-These scripts ensure that token operations are performed atomically,
-preventing race conditions in token validation and rotation.
+Lua sources loaded at import time, so a syntax error in a script surfaces at
+startup rather than on the first rotation. Rotation has to read the old key,
+stamp the used marker and answer a verdict without another client interleaving
+between those steps, which is why it is a script and not a pipeline.
 """
 
 from pathlib import Path

--- a/src/core/auth/redis_scripts.py
+++ b/src/core/auth/redis_scripts.py
@@ -1,8 +1,10 @@
 """
-Lua sources loaded at import time, so a syntax error in a script surfaces at
-startup rather than on the first rotation. Rotation has to read the old key,
-stamp the used marker and answer a verdict without another client interleaving
-between those steps, which is why it is a script and not a pipeline.
+Lua sources for the steps that must not interleave. Rotation reads the old
+refresh key, stamps the used marker and settles on a verdict as one operation;
+spread over round-trips, two concurrent refreshes could both come back valid.
+
+Importing this module only reads the files - Redis parses a script on its first
+EVAL, so a syntax error here surfaces on the first rotation, never at startup.
 """
 
 from pathlib import Path

--- a/src/core/auth/token_helpers.py
+++ b/src/core/auth/token_helpers.py
@@ -123,8 +123,9 @@ async def execute_token_rotation(
 
     Answers 'OK' or raises; there is no other return. GRACE is a double-submit
     inside the reuse window and leaves the session family intact, while REUSED
-    and INVALID wipe every session of the subject first. All three answer the
-    same generic 401, so a caller cannot learn which one it hit.
+    and INVALID wipe every session of the subject first. All three raise 401
+    under one error code, but the message a detected reuse carries differs from
+    the other two and reaches the client - only the code is uniform.
     """
 
     refresh_ttl_seconds = config.jwt.REFRESH_TOKEN_EXPIRE_MINUTES * 60

--- a/src/core/auth/token_helpers.py
+++ b/src/core/auth/token_helpers.py
@@ -1,8 +1,6 @@
 """
-Helper functions for token operations.
-
-This module contains utility functions for working with JWT tokens,
-including validation and token invalidation.
+Redis-side session bookkeeping shared by every realm: what invalidating a
+session removes, and what rotating a refresh token does atomically.
 """
 
 from collections.abc import Awaitable
@@ -28,10 +26,6 @@ async def invalidate_all_sessions(
 
     used:* markers are deliberately left to their TTL: the refresh keys are
     gone after the wipe, so a replayed rotated-out token cannot rotate anyway.
-
-    Args:
-        subject_id: The subject ID whose sessions should be invalidated
-        keys: The realm's Redis key builder.
     """
     index_key = keys.sessions(subject_id)
     # The shared client decodes responses, so members arrive as str; the cast
@@ -60,14 +54,8 @@ async def invalidate_session(
     keys: AuthRedisKeyBuilder,
 ) -> None:
     """
-    Invalidates a single session by deleting its active auth keys and
-    removing it from the sessions:{uid} index.
-
-    Args:
-        subject_id: The subject ID whose session should be invalidated.
-        session_id: The session identifier to invalidate.
-        redis_client: Redis client used to delete the active token keys.
-        keys: The realm's Redis key builder.
+    Drop one session: its active auth keys, and its entry in the
+    sessions:{uid} index that invalidate_all_sessions walks.
     """
     await redis_client.delete(
         keys.access(subject_id, session_id),
@@ -80,17 +68,11 @@ async def validate_token_structure(
     payload: JWTPayload, redis_client: Redis, *, keys: AuthRedisKeyBuilder
 ) -> tuple[str, str, str]:
     """
-    Validates that a token payload has all required fields.
+    Read the (subject, session, jti) triple a rotation needs.
 
-    Args:
-        payload: The JWT payload to validate
-        keys: The realm's Redis key builder.
-
-    Returns:
-        tuple: A tuple containing subject_id, session_id, and jti
-
-    Raises:
-        UnauthorizedException: If the token structure is invalid
+    A payload that names a subject but is missing a session or a jti is not a
+    token this system ever minted, so it costs that subject every session
+    before the generic 401 - the shape can only come from tampering.
     """
     subject_id = payload.get("sub")
     session_id = payload.get("session_id")
@@ -137,22 +119,12 @@ async def execute_token_rotation(
     keys: AuthRedisKeyBuilder,
 ) -> str:
     """
-    Executes the atomic token rotation operation using a Lua script.
+    Run the rotation script and translate its verdict.
 
-    Args:
-        subject_id: The subject ID from the token
-        session_id: The session ID from the token
-        jti: The JTI (JWT ID) from the token
-        keys: The realm's Redis key builder.
-
-    Returns:
-        str: The result of the token rotation operation ('OK' - every other
-        script answer raises)
-
-    Raises:
-        UnauthorizedException: If the token has been reused or is invalid.
-        A replay within the grace window answers the same generic 401 as an
-        invalid token but leaves the session family intact.
+    Answers 'OK' or raises; there is no other return. GRACE is a double-submit
+    inside the reuse window and leaves the session family intact, while REUSED
+    and INVALID wipe every session of the subject first. All three answer the
+    same generic 401, so a caller cannot learn which one it hit.
     """
 
     refresh_ttl_seconds = config.jwt.REFRESH_TOKEN_EXPIRE_MINUTES * 60

--- a/src/core/auth/tokens.py
+++ b/src/core/auth/tokens.py
@@ -87,15 +87,11 @@ async def create_access_token(
     session_id: str | None = None,
 ) -> str:
     """
-    Create a new JWT access token
+    Issue an access token and register its jti under the session's Redis key.
 
-    Args:
-        data: Dictionary containing token data (must include 'sub' key with subject ID)
-        redis_client: Redis client used for active JTI tracking.
-        realm: The auth contour whose secret and key namespace issue the token.
-        session_id: Optional session ID for tracking multiple sessions per subject
-    Returns:
-        str: Encoded JWT access token
+    `data` must carry `sub`, which the annotation cannot say. Omitting
+    `session_id` does not mean the current session - it opens a new one, which
+    is what login wants and what a refresh must never do.
     """
     if session_id is None:
         session_id = str(uuid4())
@@ -121,15 +117,10 @@ async def create_refresh_token(
     session_id: str | None = None,
 ) -> str:
     """
-    Create a new JWT refresh token
+    Issue a refresh token and register its jti under the session's Redis key.
 
-    Args:
-        data: Dictionary containing token data (must include 'sub' key with subject ID)
-        redis_client: Redis client used for active JTI tracking.
-        realm: The auth contour whose secret and key namespace issue the token.
-        session_id: Optional session ID for tracking multiple sessions per subject
-    Returns:
-        str: Encoded JWT refresh token
+    Same contract as create_access_token: `sub` is required inside `data`, and
+    an omitted `session_id` opens a new session rather than continuing one.
     """
     if session_id is None:
         session_id = str(uuid4())
@@ -151,23 +142,12 @@ async def rotate_refresh_token(
     old_payload: JWTPayload, redis_client: Redis, *, realm: AuthRealm
 ) -> str:
     """
-    Rotate a refresh token by creating a new one while invalidating the old one.
+    Mint a replacement refresh token inside the same session and burn the old one.
 
-    This function implements the token rotation pattern for refresh tokens:
-    1. Validate token structure and extract the necessary fields
-    2. Atomically invalidate the old token and mark it as used
-    3. Create a new token in the same logical session
-
-    Args:
-        old_payload: The payload from the old refresh token
-        redis_client: Redis client used to validate and rotate token state.
-        realm: The auth contour whose secret and key namespace own the session.
-
-    Returns:
-        str: A new refresh token
-
-    Raises:
-        UnauthorizedException: If the token is invalid, has been reused, or has other security issues
+    Presenting a token that was already rotated out is theft until proven
+    otherwise: outside the short grace window it costs the subject every
+    session, not just this request. The new token keeps the old session id, so
+    a client that refreshes does not appear as a new login.
     """
 
     subject_id, old_session_id, old_jti = await validate_token_structure(

--- a/src/core/auth/usecases/logout.py
+++ b/src/core/auth/usecases/logout.py
@@ -10,24 +10,10 @@ logger = get_logger(__name__)
 
 class LogoutUseCase:
     """
-    Invalidate one realm's current session or every session of one subject.
+    Invalidate one realm's current session, or every session of one subject.
 
-    Inputs:
-    - subject_id: id of the subject the session(s) belong to.
-    - session_id: id of the session to invalidate when not wiping all sessions.
-    - terminate_all_sessions: wipe every session of the subject instead of
-      just the current one.
-
-    Workflow:
-    1) Delete either every session in the subject's index, or just the named
-       session's active auth keys, through the realm's key builder.
-    2) Report success.
-
-    Side effects:
-    - Removes the corresponding realm-scoped Redis keys.
-
-    Returns:
-    - SuccessResponse with a successful operation flag.
+    `terminate_all_sessions` picks between the two. Both go through the realm's
+    key builder, so nothing here names a concrete realm.
     """
 
     def __init__(self, redis_client: Redis, realm: AuthRealm) -> None:

--- a/src/core/auth/usecases/refresh_access.py
+++ b/src/core/auth/usecases/refresh_access.py
@@ -20,37 +20,13 @@ class RefreshAccessUseCase(Generic[PrincipalT]):
     """
     Rotate a refresh token and mint a new access token for the same session.
 
-    Inputs:
-    - principal: the principal named by the refresh token, already resolved.
-    - old_token_payload: JWTPayload decoded from the presented refresh token.
+    A principal that fails the realm's admission gate is told the real reason,
+    unlike login: the caller already proved possession of a valid refresh
+    token, so there is nothing left to enumerate. Realm-agnostic code has no
+    email to mask, so the rejection is logged against the subject id.
 
-    Validations:
-    - The principal must pass the realm's admission gate (`admission`);
-      unlike login, the real rejection reason is reported, since the caller
-      already proved possession of a valid refresh token.
-    - The refresh token must be valid and not reused (rotate_refresh_token
-      handles reuse detection and session invalidation).
-
-    Workflow:
-    1) Run the realm's admission gate against the principal, logging the
-       subject id and the rejection reason on failure before re-raising -
-       realm-agnostic code has no email to mask, so the subject id is logged.
-    2) Rotate the refresh token: this invalidates the old one, registers it
-       used, and detects reuse.
-    3) Decode the new refresh token to read the session id it carries.
-    4) Build access-token claims via `claims_builder` and issue a new access
-       token bound to that session.
-
-    Side effects:
-    - Rotates refresh-token state in Redis; a detected reuse wipes every
-      session of the subject (see rotate_refresh_token).
-
-    Errors:
-    - Whatever `admission` raises for a principal that fails admission.
-    - UnauthorizedException: the refresh token is invalid, expired or reused.
-
-    Returns:
-    - TokenModel with the new access and refresh tokens.
+    Rotation detects reuse, and a detected reuse wipes every session of the
+    subject rather than only failing this request.
     """
 
     def __init__(

--- a/src/core/database/session.py
+++ b/src/core/database/session.py
@@ -19,18 +19,5 @@ async def get_session() -> AsyncGenerator[AsyncSession]:
 async def get_unit_of_work(
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> AsyncGenerator[ApplicationUnitOfWork]:
-    """
-    Dependency injection function that provides a Unit of Work instance.
-
-    This function creates a new ApplicationUnitOfWork for each request
-    and yields it to the caller. This is intended to be used as a FastAPI
-    dependency in route handlers.
-
-    Args:
-        session: SQLAlchemy AsyncSession, injected automatically from get_session
-
-    Yields:
-        ApplicationUnitOfWork: A Unit of Work instance for transaction management
-    """
     uow = await get_uow(session)
     yield uow

--- a/src/core/errors/handlers.py
+++ b/src/core/errors/handlers.py
@@ -43,18 +43,10 @@ def format_log_message(
     additional_info: dict[str, Any] | None = None,
     include_request_path: bool = False,
 ) -> str:
-    """
-    Format error message for logging
+    """Compose the one-line record an error handler logs.
 
-    Args:
-        request: FastAPI Request object
-        error_type: Type of error
-        message: Error message
-        additional_info: Additional context information for logs only (not shown to clients)
-        include_request_path: Include request path and method in the log message
-
-    Returns:
-        Formatted log message
+    `additional_info` is log-only context and never reaches the response body,
+    which is why internals may go in there and nowhere else.
     """
     raw_msg = message or "No additional details available"
     msg = " ".join(raw_msg.split())

--- a/src/core/limiter/depends.py
+++ b/src/core/limiter/depends.py
@@ -27,8 +27,11 @@ class _InMemoryRateLimitWindow:
 
 class RateLimiter:
     """
-    HTTP rate limiter dependency for FastAPI endpoints.
-    Applies rate-limiting logic via Redis and Lua scripting.
+    Fixed-window rate limiter backed by a Redis Lua script.
+
+    When Redis is unreachable it falls back to a per-process in-memory window,
+    so an outage degrades the limit to per-instance instead of removing it, and
+    reports itself to Sentry once with a cooldown rather than per request.
     """
 
     _fallback_windows: ClassVar[dict[str, _InMemoryRateLimitWindow]] = {}
@@ -53,13 +56,10 @@ class RateLimiter:
         ] = FastAPILimiter.http_callback,
     ) -> None:
         """
-        Initialize the rate limiter with time windows and custom behaviors.
-
-        Args:
-            times: Number of allowed requests in the time window
-            milliseconds/seconds/minutes/hours: Time window duration
-            identifier: Async function to generate unique rate-limit key
-            callback: Async function to call when limit exceeded
+        The four duration arguments add up into one window, so
+        `seconds=30, minutes=1` is a 90-second window rather than a conflict.
+        `identifier` decides what the limit counts: the default buckets by
+        client IP, and `get_user_id_from_token` buckets per user instead.
         """
         if FastAPILimiter.identifier is None or FastAPILimiter.http_callback is None:
             raise RuntimeError("FastAPILimiter must be initialized before use.")
@@ -190,10 +190,7 @@ class RateLimiter:
 
     async def __call__(self, request: Request, response: Response) -> None:
         """
-        FastAPI-compatible call method that applies rate limiting.
-
-        Raises:
-            HTTPException 429 if the limit is exceeded
+        Count this request against its bucket, or raise 429 with Retry-After.
         """
         if not FastAPILimiter.is_initialized():
             raise RuntimeError("FastAPILimiter must be initialized before use.")

--- a/src/core/utils/datetime_utils.py
+++ b/src/core/utils/datetime_utils.py
@@ -3,8 +3,11 @@ from zoneinfo import ZoneInfo
 
 
 def get_utc_now() -> datetime:
-    """The project's only clock. Every datetime that reaches a column, a cache
-    key or a comparison originates here, so none of them is ever naive."""
+    """The application clock: every expiry, cache stamp and comparison this
+    code computes starts here, offset-aware in UTC, so no naive value ever
+    reaches one. It is not the only clock in the system - TimestampMixin leaves
+    created_at/updated_at to `func.now()`, so those columns carry the database's
+    time and patching this function does not move them."""
     return datetime.now(ZoneInfo("UTC"))
 
 

--- a/src/core/utils/datetime_utils.py
+++ b/src/core/utils/datetime_utils.py
@@ -3,15 +3,8 @@ from zoneinfo import ZoneInfo
 
 
 def get_utc_now() -> datetime:
-    """
-    Get the current date and time in UTC.
-
-    This function returns the current time with timezone information set to UTC,
-    ensuring that the returned datetime object is offset-aware.
-
-    Returns:
-        datetime: The current date and time in UTC with tzinfo set to ZoneInfo("UTC").
-    """
+    """The project's only clock. Every datetime that reaches a column, a cache
+    key or a comparison originates here, so none of them is ever naive."""
     return datetime.now(ZoneInfo("UTC"))
 
 

--- a/src/core/utils/security.py
+++ b/src/core/utils/security.py
@@ -61,9 +61,8 @@ async def verify_password(plain_password: str, hashed_password: str) -> bool:
 
 
 def generate_otp(length: int = 5) -> str:
-    """
-    Generate a random numeric OTP with a fixed length.
-    """
+    """Digits only, drawn from `secrets` - short enough to retype, so the
+    throttle in front of every OTP flow is what makes it safe, not its entropy."""
     if length <= 0:
         raise ValueError(f"OTP length must be greater than 0, given {length}.")
 
@@ -71,19 +70,11 @@ def generate_otp(length: int = 5) -> str:
 
 
 def mask_email(email: str | EmailStr) -> str:
-    """
-    Masks an email address by replacing part of the local and domain parts
-    with asterisks.
-    Mask pattern: ab***@cd***
+    """Mask an address down to `ab***@cd***` for logs and Sentry.
 
-    Args:
-        email: str
-            A string containing the email address to be masked.
-
-    Returns:
-        str
-            A masked version of the provided email address with part of
-            the local and domain obscured.
+    Never raises. It runs on logging and error paths, where a malformed address
+    must not replace the record it was meant to annotate; anything unparseable
+    masks to `***`.
     """
     try:
         email_str = str(email)
@@ -113,5 +104,6 @@ def build_throttle_key(prefix: str, identifier: str) -> str:
 
 
 def normalize_email(email: str) -> str:
-    """Normalize an email address."""
+    """Strip surrounding whitespace and case-fold - the one canonical form
+    stored, compared and hashed into throttle keys."""
     return email.strip().lower()

--- a/src/main/presentation.py
+++ b/src/main/presentation.py
@@ -34,16 +34,7 @@ EXCEPTION_HANDLERS: tuple[tuple[type[Exception], HandlerCallable], ...] = (
 
 
 def include_routers(app: FastAPI) -> None:
-    """
-    Includes API routers into the FastAPI application.
-
-    Parameters:
-        app (FastAPI): The FastAPI application instance to which routers will
-        be added.
-
-    Returns:
-        None
-    """
+    """Mount every domain router under /v1. A new router is added here."""
     v1_router = APIRouter()
     v1_router.include_router(user_routers.router, prefix="/users", tags=["Users"])
     v1_router.include_router(note_routers.router, prefix="/notes", tags=["Notes"])
@@ -53,16 +44,11 @@ def include_routers(app: FastAPI) -> None:
 
 
 def include_exceptions_handlers(app: FastAPI) -> None:
-    """
-    Registers exception handlers for various custom exceptions with the provided FastAPI
-    application instance.
+    """Register the exception handlers.
 
-    Parameters:
-        app (FastAPI): The FastAPI application instance to which the exception handlers
-        will be added.
-
-    Returns:
-        None
+    A new project exception needs no entry here: the generic handler serializes
+    whatever `status_code`, `error_code` and `log_level` the class declares.
+    Only errors raised outside that hierarchy need one of their own.
     """
     for exception_type, handler in EXCEPTION_HANDLERS:
         app.add_exception_handler(exception_type, handler)

--- a/src/note/usecases/create_note.py
+++ b/src/note/usecases/create_note.py
@@ -15,27 +15,8 @@ class CreateNoteUseCase:
     """
     Create a note owned by the current user.
 
-    Inputs:
-    - data: NoteCreateModel with the title and optional content.
-    - owner_id: UUID of the user the note will belong to.
-
-    Validations:
-    - None beyond schema validation; ownership is derived from the caller's
-      identity, never taken from the request body.
-
-    Workflow:
-    1) Create the note row scoped to owner_id.
-    2) Flush pending DB changes.
-    3) Commit the transaction.
-
-    Side effects:
-    - Creates a new note record.
-
-    Errors:
-    - None beyond persistence failures surfaced by the repository.
-
-    Returns:
-    - NoteViewModel: the created note.
+    Ownership is taken from the authenticated caller, never from the request
+    body, so a note cannot be created in someone else's name.
     """
 
     def __init__(self, uow: ApplicationUnitOfWork) -> None:

--- a/src/note/usecases/delete_note.py
+++ b/src/note/usecases/delete_note.py
@@ -17,31 +17,9 @@ class DeleteNoteUseCase:
     """
     Soft-delete a note.
 
-    Inputs:
-    - note_id: UUID of the note to delete.
-    - current_user: the caller, used for the ownership/permission check.
-
-    Validations:
-    - The note must exist.
-    - The caller must own the note or hold MANAGE_NOTES.
-
-    Workflow:
-    1) Load the note.
-    2) Enforce ownership/permission via ensure_note_access.
-    3) Soft-delete the note.
-    4) Flush pending DB changes.
-    5) Commit the transaction.
-
-    Side effects:
-    - Marks the note as deleted (is_deleted, deleted_at).
-
-    Errors:
-    - InstanceNotFoundException: if the note does not exist, or the caller
-      neither owns it nor holds MANAGE_NOTES (anti-enumeration: both cases
-      answer the same 404).
-
-    Returns:
-    - None.
+    A note the caller neither owns nor may manage answers the same 404 as a
+    note that does not exist: a foreign id has to stay indistinguishable from
+    a missing one, or the endpoint enumerates other people's notes.
     """
 
     def __init__(self, uow: ApplicationUnitOfWork) -> None:

--- a/src/note/usecases/update_note.py
+++ b/src/note/usecases/update_note.py
@@ -16,36 +16,12 @@ logger = get_logger(__name__)
 
 class UpdateNoteUseCase:
     """
-    Update a note's title and/or content.
+    Update a note's title and content.
 
-    Inputs:
-    - note_id: UUID of the note to update.
-    - data: NoteUpdateModel with the fields to change; an omitted field is
-      left untouched (exclude_unset), an explicit null fails schema validation.
-    - current_user: the caller, used for the ownership/permission check.
-
-    Validations:
-    - The note must exist.
-    - The caller must own the note or hold MANAGE_NOTES.
-
-    Workflow:
-    1) Load the note.
-    2) Enforce ownership/permission via ensure_note_access.
-    3) Apply the changed fields.
-    4) Flush pending DB changes.
-    5) Refresh the server-generated updated_at value.
-    6) Commit the transaction.
-
-    Side effects:
-    - Updates the note record.
-
-    Errors:
-    - InstanceNotFoundException: if the note does not exist, or the caller
-      neither owns it nor holds MANAGE_NOTES (anti-enumeration: both cases
-      answer the same 404).
-
-    Returns:
-    - NoteViewModel: the updated note.
+    PATCH semantics: an omitted field is left untouched (exclude_unset) and an
+    explicit null fails schema validation, because both columns are
+    non-nullable. A note the caller neither owns nor may manage answers the
+    same 404 as a missing one.
     """
 
     def __init__(self, uow: ApplicationUnitOfWork) -> None:

--- a/src/user/auth/permissions/ownership.py
+++ b/src/user/auth/permissions/ownership.py
@@ -12,14 +12,10 @@ from src.user.models import User
 
 
 def _matches_user_id(candidate: str, user_id: UUID) -> bool:
-    """Compare a candidate string (from URL) with a UUID, handling case differences.
+    """Compare a raw path parameter against a UUID by value, not by spelling.
 
-    Args:
-        candidate: Raw string from the URL path parameter.
-        user_id: The UUID to compare against.
-
-    Returns:
-        True if candidate parses as a UUID matching user_id, False otherwise.
+    A candidate that is no UUID at all answers False rather than raising: the
+    caller owes both cases the same 404.
     """
     try:
         return UUID(candidate) == user_id

--- a/src/user/auth/usecases/login.py
+++ b/src/user/auth/usecases/login.py
@@ -44,47 +44,29 @@ LOGIN_FAILURES_WINDOW_SECONDS = 15 * 60
 
 class LoginUserUseCase:
     """
-    Log in a user and return access and refresh tokens.
+    Log in a user and issue an access and refresh token pair.
 
-    Inputs:
-    - data: LoginUserModel containing email and password.
+    The per-email failure counter is checked before any database or password
+    hash work, so a flood of guesses costs one Redis read each. An unknown
+    email is still verified against a dummy hash, so timing does not reveal
+    whether the account exists. Every credential failure feeds the counter; an
+    admission failure with a correct password does not, since that caller
+    already proved ownership of the account.
 
-    Validations:
-    - The email must be under the failed-login limit for the current window
-      (LoginThrottle).
-    - User must exist.
-    - Password must be correct.
-    - Account must pass admission (verified and active) - see policies.py.
-
-    Workflow:
-    1) Reject when the per-email failure counter has reached the limit,
-       before any database or password-hash work is spent.
-    2) Retrieve user by email.
-    3) Verify password (using dummy hash if user not found to prevent timing
-       attacks). Either failure - unknown email included - feeds the counter;
-       an admission violation with a correct password does not.
-    4) Check account admission; a violation is masked into the same error as
-       bad credentials (anti-enumeration).
-    5) Rehash and persist the password if needed.
-    6) Invalidate the user cache namespace.
-    7) Commit the transaction, clear the failure counter, and issue an access
-       and refresh token pair for a new session.
+    Wrong credentials, an unverified account and a blocked account all answer
+    InvalidCredentialsError under one code, by design - the client learns that
+    login failed and nothing else.
 
     Side effects:
-    - Persists password hash updates when rehashing is required.
-    - Bumps the user:{id} cache namespace version twice (pre- and post-commit) -
-      every write to the user row does this unconditionally, including this one
-      where the row is only sometimes touched (the rehash branch), so no one
-      has to remember an exception to the rule.
-    - Token creation handles its own caching.
+    - Persists a rehashed password when the stored hash uses outdated parameters.
+    - Bumps the user:{id} cache namespace version twice, pre- and post-commit.
+      Every write to the user row does this unconditionally, this one included,
+      where the row is only sometimes touched - so no one has to remember an
+      exception to the rule.
 
     Errors:
-    - TooManyRequestsException: the email has exhausted the failure window.
-    - InvalidCredentialsError: wrong credentials, unverified or blocked account -
-      one code by design (anti-enumeration).
-
-    Returns:
-    - TokenModel with access and refresh tokens.
+    - TooManyRequestsException: the email has exhausted its failure window.
+    - InvalidCredentialsError: wrong credentials, unverified or blocked account.
     """
 
     def __init__(

--- a/src/user/auth/usecases/register.py
+++ b/src/user/auth/usecases/register.py
@@ -18,31 +18,13 @@ logger = get_logger(__name__)
 
 class RegisterUseCase:
     """
-    Register a new user and send a verification email.
+    Register a user and send the verification email.
 
-    Inputs:
-    - data: CreateUserModel containing user registration details.
-
-    Validations:
-    - Email and username must be unique (handled by DB constraints/repository).
-
-    Workflow:
-    1) Create a new user record in the database.
-    2) Store the verification email delivery in the outbox within the same
-       transaction.
-    3) Commit the transaction (the outbox publish hook fires after commit).
-
-    Side effects:
-    - Creates a user record in the database.
-    - Inserts an outbox row for the verification email and publishes it
-      after commit.
-
-    Errors:
-    - Duplicate email/username surfaces as IntegrityError and is answered 409
-      with code "already_exists" by the database error middleware.
-
-    Returns:
-    - UserProfileViewModel: the newly created user profile.
+    The email is written to the outbox inside the same transaction as the user
+    row, so a committed registration always has a queued email and a rolled
+    back one never leaves a stray send. A duplicate email or username reaches
+    the database error middleware as an IntegrityError and is answered 409
+    `already_exists` there, not here.
     """
 
     def __init__(

--- a/src/user/auth/usecases/resend_verification.py
+++ b/src/user/auth/usecases/resend_verification.py
@@ -20,30 +20,13 @@ logger = get_logger(__name__)
 
 class SendVerificationUseCase:
     """
-    Resend a verification email to a user.
+    Resend the verification email.
 
-    Inputs:
-    - data: ResendVerificationModel containing user email.
-
-    Validations:
-    - User must exist (if not, return success to prevent email enumeration).
-    - User must not be already verified (if so, return success).
-
-    Workflow:
-    1) Retrieve user by email.
-    2) Check if user is already verified.
-    3) Store the verification email delivery in the outbox using the notifier
-       with throttling.
-    4) Commit the transaction (the outbox publish hook fires after commit).
-
-    Side effects:
-    - Inserts an outbox row for the verification email and publishes it
-      after commit.
-    - Sets/updates a throttle key in Redis; releases it if the transaction
-      fails to commit.
-
-    Returns:
-    - SuccessResponse: success=True regardless of whether email was sent (for privacy).
+    Answers success whether or not anything was sent: an unknown address and an
+    already verified one must look identical from outside, or the endpoint
+    confirms who has an account. The notifier's throttle key is released when
+    the transaction fails to commit, so a failed attempt does not lock the
+    address out of a retry.
     """
 
     def __init__(

--- a/src/user/auth/usecases/reset_password_confirm.py
+++ b/src/user/auth/usecases/reset_password_confirm.py
@@ -26,41 +26,19 @@ logger = get_logger(__name__)
 
 class ResetPasswordConfirmUseCase:
     """
-    Confirm password reset using a valid JWT reset token.
+    Confirm a password reset with a single-use token and store the new password.
 
-    Inputs:
-    - data: ResetPasswordModel containing the token and the new password.
-
-    Validations:
-    - Token must be valid and not expired.
-    - Token mode must be 'reset_password_token'.
-    - Token JTI must match the active Redis entry for the email.
-    - Email must be present in the token.
-    - User must exist in the database.
-
-    Workflow:
-    1) Decode and validate the JWT reset token.
-    2) Extract email and validate the active JTI in Redis.
-    3) Hash and update the user's password in the database.
-    4) Flush pending DB changes.
-    5) Delete the active reset-token key and invalidate all user sessions.
-    6) Invalidate the user cache namespace.
-    7) Commit the transaction.
+    An invalid, expired or superseded token answers success=False instead of
+    raising, so a wrong token cannot be told apart from a wrong email.
 
     Side effects:
-    - Updates user record in the database.
-    - Deletes the active reset-token key from Redis before commit to avoid
-      partial-success password changes when Redis is unavailable.
-    - Deletes user session keys from Redis before commit for the same reason.
-    - Clears the per-email login-failure counter (the reset proves mailbox
-      ownership, so a throttled email must not stay locked out of login).
-    - Bumps the user:{id} cache namespace version twice (pre- and post-commit).
-
-    Errors:
-    - None (returns success=False for invalid tokens/users).
-
-    Returns:
-    - SuccessResponse: success=True if password was reset, False otherwise.
+    - Deletes the active reset-token key and every session key of the user
+      before the commit rather than after: with Redis unavailable the change
+      then fails as a whole, instead of leaving a new password alongside
+      sessions that still hold the old one.
+    - Clears the per-email login-failure counter. The reset proves mailbox
+      ownership, so a throttled address must not stay locked out of login.
+    - Bumps the user:{id} cache namespace version twice, pre- and post-commit.
     """
 
     def __init__(

--- a/src/user/auth/usecases/reset_password_request.py
+++ b/src/user/auth/usecases/reset_password_request.py
@@ -19,30 +19,12 @@ logger = get_logger(__name__)
 
 class ResetPasswordRequestUseCase:
     """
-    Request a password reset email for a user.
+    Send a password reset email.
 
-    Inputs:
-    - data: SendResetPasswordRequestModel containing user email.
-
-    Validations:
-    - User must exist (if not, return success to prevent email enumeration).
-
-    Workflow:
-    1) Retrieve user by email.
-    2) Store the password reset email delivery in the outbox using the
-       notifier with throttling. If a reset email was already sent recently
-       and the throttle window has not elapsed, return success=True without
-       committing, to prevent email enumeration.
-    3) Commit the transaction (the outbox publish hook fires after commit).
-
-    Side effects:
-    - Inserts an outbox row for the password reset email and publishes it
-      after commit.
-    - Sets/updates a throttle key in Redis; releases it if the transaction
-      fails to commit.
-
-    Returns:
-    - SuccessResponse: success=True regardless of whether email was sent.
+    Answers success whether or not anything was sent, the unelapsed throttle
+    window included: a caller must not be able to tell an unknown address from
+    one that was mailed a minute ago. The throttle key is released when the
+    transaction fails to commit.
     """
 
     def __init__(

--- a/src/user/auth/usecases/verify_email.py
+++ b/src/user/auth/usecases/verify_email.py
@@ -27,12 +27,15 @@ class VerifyEmailUseCase:
     """
     Verify an email address with a single-use token.
 
-    An already verified account consumes the token and answers success as well,
-    so clicking the link twice looks the same as clicking it once. An invalid
-    or superseded token, and an email naming no user, answer success=False
-    instead of raising - the endpoint must not confirm who has an account. The
-    token is consumed after the commit, so a failed transaction leaves the link
-    usable.
+    An invalid, expired or superseded token, and an email naming no user,
+    answer success=False instead of raising - the endpoint must not confirm who
+    has an account. A second click on an already used link lands there too: the
+    challenge is invalidated after the commit, so the link no longer decodes.
+    The already-verified branch covers the other case - a token still live for
+    an account that got verified some other way - and answers success for it.
+
+    Consuming the token after the commit rather than before leaves the link
+    usable when the transaction fails.
     """
 
     def __init__(

--- a/src/user/auth/usecases/verify_email.py
+++ b/src/user/auth/usecases/verify_email.py
@@ -25,35 +25,14 @@ logger = get_logger(__name__)
 
 class VerifyEmailUseCase:
     """
-    Verify a user's email address using a JWT token.
+    Verify an email address with a single-use token.
 
-    Inputs:
-    - token: JWT token containing the user's email.
-
-    Validations:
-    - Token must be valid and not expired.
-    - Token JTI must match the active Redis entry for the email.
-    - Email must be present in the token.
-    - User must exist in the database.
-
-    Workflow:
-    1) Decode and validate the JWT token.
-    2) Extract email and validate the active JTI in Redis.
-    3) Retrieve user by normalized email.
-    4) If user is already verified, consume the token and return success.
-    5) Update user's is_verified status to True.
-    6) Invalidate the user cache namespace.
-    7) Commit the transaction.
-    8) Consume the token.
-
-    Side effects:
-    - Updates user record in the database.
-    - Deletes the active verification-token key from Redis after successful use.
-    - Bumps the user:{id} cache namespace version twice (pre- and post-commit).
-
-    Returns:
-    - SuccessResponse: success=True if verified or already verified, False if the
-      token is invalid/inactive or the email/user is not found.
+    An already verified account consumes the token and answers success as well,
+    so clicking the link twice looks the same as clicking it once. An invalid
+    or superseded token, and an email naming no user, answer success=False
+    instead of raising - the endpoint must not confirm who has an account. The
+    token is consumed after the commit, so a failed transaction leaves the link
+    usable.
     """
 
     def __init__(

--- a/src/user/models.py
+++ b/src/user/models.py
@@ -40,26 +40,14 @@ class User(Base, UUID7IDMixin, TimestampMixin, SoftDeleteMixin):
     is_verified: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
 
-    """relationships"""
-    # Add relationships here
-
     @validates("password_hash")
     def validate_password_hash(self, _: str, value: str) -> str:
         """
-        Validate that the password hash looks like a supported hash format.
+        Reject a plaintext password assigned straight to the column.
 
-        Args:
-            _: str
-                Unused parameter
-            value: str
-                The new or updated password hash provided for validation.
-
-        Returns:
-            str
-                The validated password hash.
-
-        Raises:
-            ValueError: If the value is not a valid password hash.
+        The guard is on the ORM attribute rather than in the service layer so
+        that no code path - a script, a fixture, a future use case - can store
+        an unhashed value by forgetting to hash it first.
         """
         if not is_password_hash(value):
             raise ValueError("Password hash must be a valid hash.")

--- a/src/user/usecases/update_password.py
+++ b/src/user/usecases/update_password.py
@@ -28,42 +28,17 @@ logger = get_logger(__name__)
 
 class UpdateUserPasswordUseCase:
     """
-    Update a user's password and invalidate all their active sessions.
+    Change the caller's own password and end every session it had.
 
-    This is the self-service change and it always proves knowledge of the
-    current password. An administrative reset of someone else's password, when
-    one is added, is a separate scenario and must not ask for it.
-
-    Inputs:
-    - data: UserNewPassword containing the current and the new password.
-    - user_id: UUID of the user updating their password.
-
-    Validations:
-    - User must exist in the database.
-    - current_password must match the stored hash.
-    - The new password must differ from the current one.
-
-    Workflow:
-    1) Load the user and verify the current password.
-    2) Hash and update user password in the database.
-    3) Flush pending DB changes.
-    4) Invalidate all active Redis sessions for the user.
-    5) Invalidate the user cache namespace.
-    6) Commit the transaction.
+    Self-service, so it always proves knowledge of the current password and
+    refuses a new password equal to it. An administrative reset of someone
+    else's password is a separate scenario and must not ask for the current one.
 
     Side effects:
-    - Updates user record in database.
-    - Deletes all user session keys from Redis before commit to avoid
-      partial-success password changes when Redis is unavailable.
-    - Bumps the user:{id} cache namespace version twice (pre- and post-commit).
-
-    Errors:
-    - InstanceNotFoundException: if the user does not exist.
-    - InvalidCredentialsError: if current_password does not match.
-    - InstanceProcessingException: if the new password repeats the current one.
-
-    Returns:
-    - SuccessResponse: success=True.
+    - Deletes every session key of the user before the commit rather than
+      after: with Redis unavailable the change then fails as a whole, instead
+      of leaving a new password alongside sessions holding the old one.
+    - Bumps the user:{id} cache namespace version twice, pre- and post-commit.
     """
 
     def __init__(

--- a/src/user/usecases/update_profile.py
+++ b/src/user/usecases/update_profile.py
@@ -18,36 +18,13 @@ logger = get_logger(__name__)
 
 class UpdateUserProfileUseCase:
     """
-    Update the current user's profile fields.
+    Update the caller's profile fields.
 
-    Inputs:
-    - data: UserProfileUpdateModel with the fields to change. A field left unset
-      is skipped (exclude_unset); an explicit `null` fails schema validation,
-      because every updatable column here is non-nullable. An entirely empty
-      body is a no-op write: it still updates zero columns, still flushes, and
-      still bumps the cache namespace - a spurious bump costs a cold cache, not
-      a stale read.
-    - user_id: UUID of the user being updated.
-
-    Validations:
-    - User must exist.
-
-    Workflow:
-    1) Apply the non-empty fields to the user row.
-    2) Flush pending DB changes.
-    3) Invalidate the user cache namespace.
-    4) Commit the transaction; an after-commit hook invalidates the
-       namespace a second time.
-
-    Side effects:
-    - Updates the user record.
-    - Bumps the user:{id} cache namespace version twice (pre- and post-commit).
-
-    Errors:
-    - InstanceNotFoundException: if the user does not exist.
-
-    Returns:
-    - UserProfileViewModel: the updated profile.
+    An unset field is skipped (exclude_unset) and an explicit null fails schema
+    validation, because every updatable column here is non-nullable. An empty
+    body is still a write: it updates zero columns, flushes, and bumps the
+    cache namespace anyway - a spurious bump costs a cold cache, a skipped one
+    could cost a stale read.
     """
 
     def __init__(


### PR DESCRIPTION
## What

The docstrings across the auth core, the use cases and the shared utilities had grown into a restatement of the signature: summaries spelling the identifier back out (`"""Validates that a token payload has all required fields."""` over `validate_token_structure`), `Args:` blocks echoing the annotations (`session: SQLAlchemy AsyncSession` under `session: AsyncSession`), `Workflow:` sections narrating three visible statements, and `Validations:` / `Errors:` sections filled with "None beyond …" to satisfy the section list. `CreateNoteUseCase` carried 25 lines of it over a four-statement body — and `src/note` is the module every new domain is copied from, so the shape was being tiled forward.

Each docstring now keeps only what a reader cannot derive from the code. 598 lines out, 178 in.

## What the boilerplate was hiding

Several facts were buried and are now the first thing stated:

- `validate_token_structure` wipes **every session of the subject** before raising — the old docstring said "Validates that a token payload has all required fields".
- `create_access_token` / `create_refresh_token` open a **new** session when `session_id` is omitted, and require `sub` inside `data`, which `dict[str, Any]` cannot say.
- `mask_email` never raises, because it runs on logging and Sentry paths where a malformed address must not replace the record.
- `User.validate_password_hash` sits on the ORM attribute so that no script, fixture or future use case can store plaintext by forgetting to hash.
- `execute_token_rotation` answers `OK` or raises; `GRACE`, `REUSED` and `INVALID` differ in whether the session family survives, and all three answer the same 401.

Also removed: a stray `"""relationships"""` marker string in `src/user/models.py`, and the "This module contains …" openings.

## Testing

`make lint` and `make test` pass — 957 passed, 18 deselected. Comments and docstrings only; no behavior changes.