### PR TITLE
fix(auth): consume single-use challenges atomically

### DIFF
--- a/docs/readme/auth-realms.md
+++ b/docs/readme/auth-realms.md
@@ -101,20 +101,30 @@ A realm that authenticates by one-time code (SMS, email) instead of a
 password reuses the same core, plus `ActiveChallengeRegistry`
 (`src/core/auth/challenges.py`):
 
-- **Never store the code itself.** `ActiveChallengeRegistry.validate`
+- **Never store the code itself.** `ActiveChallengeRegistry.consume`
   (`src/core/auth/challenges.py`) checks the presented value against the
   stored one with a plain equality comparison, so the stored value must be
   deterministic - Argon2 (`src/core/utils/security.py`'s password hasher) is
   salted and produces a different hash every call, which would make every
-  validation fail. Use a keyed digest instead: `hmac.new(realm.one_time_secret(purpose).encode(), code.encode(), hashlib.sha256).hexdigest()`,
+  check fail. Use a keyed digest instead: `hmac.new(realm.one_time_secret(purpose).encode(), code.encode(), hashlib.sha256).hexdigest()`,
   computed the same way to store and to compare. Keying the digest with the
   realm's own one-time secret means a Redis dump still doesn't hand a reader
   a table to brute-force the code against.
-- **Count attempts separately from the challenge.** The challenge key holds
-  the live code's digest; a second, realm-keyed counter tracks failed
-  attempts against it, independent of the challenge's own TTL. Exhausting the
-  counter should retire the challenge (`ActiveChallengeRegistry.invalidate`)
-  rather than leaving it guessable until it expires on its own.
+- **A correct code is spent by the check itself.** `consume` compares and
+  deletes in one Redis operation, so exactly one of any number of concurrent
+  presentations of one code gets through, and a successful check needs no
+  follow-up `invalidate` - calling one retires whatever challenge is live by
+  then, which may already be a newer one. The other side of that contract: a
+  caller whose own work fails after a successful `consume` must issue a new
+  code rather than expect the old one to work again.
+- **Count attempts separately from the challenge.** A wrong value deliberately
+  consumes nothing - the code stays live for its owner - so this class alone
+  gives a short numeric code no brute-force resistance, and the counter is
+  mandatory rather than optional for one. The challenge key holds the live
+  code's digest; a second, realm-keyed counter tracks failed attempts against
+  it, independent of the challenge's own TTL. Exhausting the counter should
+  retire the challenge (`ActiveChallengeRegistry.invalidate`) rather than
+  leaving it guessable until it expires on its own.
 - **TTLs are minutes, not seconds** - an OTP a user has to fetch from a text
   message or an inbox needs more slack than an in-process token exchange.
 - **Sending is a side effect, so it lives in a UseCase**, calling the SMS or

--- a/src/core/auth/challenges.py
+++ b/src/core/auth/challenges.py
@@ -17,8 +17,11 @@ class ActiveChallengeRegistry:
     link, the hash of a code for an OTP - so issuing a new challenge always
     retires the previous one. `consume` takes the challenge away in the same
     operation that checks it, so of any number of callers presenting one value
-    exactly one gets through. The identifier is hashed into the key, so an
-    email or a phone number never reaches SCAN, MONITOR or an RDB dump.
+    exactly one gets through. A realm whose value is guessable must pair this
+    with a failure counter of its own: a wrong value deliberately consumes
+    nothing, so a short numeric code survives unlimited guesses at this layer.
+    The identifier is hashed into the key, so an email or a phone number never
+    reaches SCAN, MONITOR or an RDB dump.
     """
 
     def __init__(self, realm: AuthRealm) -> None:

--- a/src/core/auth/challenges.py
+++ b/src/core/auth/challenges.py
@@ -1,17 +1,23 @@
+from collections.abc import Awaitable
+from typing import cast
+
 from redis.asyncio import Redis
 
 from src.core.auth.realm import AuthRealm
+from src.core.auth.redis_scripts import CONSUME_CHALLENGE_SCRIPT
 from src.core.errors.exceptions import UnauthorizedException
 
 INVALID_CHALLENGE_MESSAGE = "Invalid or expired token."
 
 
 class ActiveChallengeRegistry:
-    """Exactly one live challenge per realm, purpose and identifier.
+    """Exactly one live challenge per realm, purpose and identifier, taken once.
 
     Holds whatever proves a challenge current - a token's jti for a signed
     link, the hash of a code for an OTP - so issuing a new challenge always
-    retires the previous one. The identifier is hashed into the key, so an
+    retires the previous one. `consume` takes the challenge away in the same
+    operation that checks it, so of any number of callers presenting one value
+    exactly one gets through. The identifier is hashed into the key, so an
     email or a phone number never reaches SCAN, MONITOR or an RDB dump.
     """
 
@@ -30,29 +36,42 @@ class ActiveChallengeRegistry:
             self._realm.keys.one_time(purpose, identifier), value, ex=ttl_seconds
         )
 
-    async def validate(
+    async def consume(
         self,
         purpose: str,
         identifier: str,
         value: str | None,
         redis_client: Redis,
     ) -> None:
-        """Confirm the presented value is the live challenge.
+        """Claim the live challenge for this caller, or raise.
 
-        Every failure - missing, superseded, expired - answers the same error:
-        telling a caller which one it was only helps an attacker.
+        Returning means the challenge matched and is already gone: the caller
+        must treat it as spent, because work that fails afterwards cannot hand
+        it back. Every failure - missing, superseded, expired, or lost to
+        another caller by a millisecond - answers the same error: telling a
+        caller which one it was only helps an attacker.
         """
         if not value:
             raise UnauthorizedException(INVALID_CHALLENGE_MESSAGE)
 
-        active = await redis_client.get(self._realm.keys.one_time(purpose, identifier))
-        active_value = (
-            active.decode() if isinstance(active, (bytes, bytearray)) else active
+        verdict = await cast(
+            Awaitable[str],
+            redis_client.eval(
+                CONSUME_CHALLENGE_SCRIPT,
+                1,  # Number of keys
+                self._realm.keys.one_time(purpose, identifier),
+                value,
+            ),
         )
-        if active_value != value:
+        if verdict != "OK":
             raise UnauthorizedException(INVALID_CHALLENGE_MESSAGE)
 
     async def invalidate(
         self, purpose: str, identifier: str, redis_client: Redis
     ) -> None:
+        """Retire the challenge whatever its value, without claiming it.
+
+        For a caller abandoning a challenge rather than acting on it - an email
+        that never left the outbox.
+        """
         await redis_client.delete(self._realm.keys.one_time(purpose, identifier))

--- a/src/core/auth/consume_challenge.lua
+++ b/src/core/auth/consume_challenge.lua
@@ -1,0 +1,16 @@
+local challenge_key = KEYS[1]
+local presented_value = ARGV[1]
+
+-- Compare and delete in one operation: spread over two round-trips, two
+-- concurrent requests holding the same value both read it as live and both
+-- proceed.
+local active = redis.call('GET', challenge_key)
+if active ~= presented_value then
+    return 'INVALID'
+end
+
+-- Not GETDEL: that deletes on a mismatch too, so anyone presenting a
+-- superseded value would retire the challenge the owner is still waiting on.
+redis.call('DEL', challenge_key)
+
+return 'OK'

--- a/src/core/auth/one_time_tokens.py
+++ b/src/core/auth/one_time_tokens.py
@@ -53,11 +53,18 @@ async def decode_one_time_token(
     expected_mode: str | None = None,
 ) -> str:
     """
-    Decode a single-use token and confirm it is still the live challenge.
+    Decode a single-use token and consume the challenge behind it.
+
+    A successful return spends the token: the challenge is gone before the
+    caller does any work, so a caller whose own work then fails must let the
+    holder ask for a new token rather than expect this one to decode again.
+    That is what the single-use guarantee costs - checking the challenge
+    without taking it lets two concurrent requests through on one token.
 
     Callers keep their own jwt.ExpiredSignatureError / jwt.InvalidTokenError
     ladders: this raises only for what can be decided after a successful
-    decode - a missing identifier, a mode mismatch, or a superseded challenge.
+    decode - a missing identifier, a mode mismatch, or a challenge that is
+    superseded, spent, or claimed by a concurrent caller first.
     """
     payload = jwt.decode(
         token,
@@ -72,7 +79,7 @@ async def decode_one_time_token(
     if not identifier:
         raise UnauthorizedException(INVALID_CHALLENGE_MESSAGE)
 
-    await ActiveChallengeRegistry(realm).validate(
+    await ActiveChallengeRegistry(realm).consume(
         purpose, identifier, payload.get("jti"), redis_client
     )
     return str(identifier)

--- a/src/core/auth/redis_scripts.py
+++ b/src/core/auth/redis_scripts.py
@@ -1,14 +1,19 @@
 """
 Lua sources for the steps that must not interleave. Rotation reads the old
 refresh key, stamps the used marker and settles on a verdict as one operation;
-spread over round-trips, two concurrent refreshes could both come back valid.
+consuming a single-use challenge compares its value and deletes it as one.
+Spread over round-trips, two concurrent callers both come back valid.
 
 Importing this module only reads the files - Redis parses a script on its first
-EVAL, so a syntax error here surfaces on the first rotation, never at startup.
+EVAL, so a syntax error here surfaces on the first call, never at startup.
 """
 
 from pathlib import Path
 
 ROTATE_REFRESH_TOKEN_SCRIPT = (
     Path(__file__).with_name("rotate_refresh_token.lua").read_text(encoding="utf-8")
+)
+
+CONSUME_CHALLENGE_SCRIPT = (
+    Path(__file__).with_name("consume_challenge.lua").read_text(encoding="utf-8")
 )

--- a/src/core/redis/core.py
+++ b/src/core/redis/core.py
@@ -1,5 +1,7 @@
 from redis.asyncio import Redis
 
+from src.core.errors.exceptions import InfrastructureException
+
 
 def create_redis_client(
     connection_url: str,
@@ -9,7 +11,19 @@ def create_redis_client(
     socket_connect_timeout: float = 5.0,
     health_check_interval: int = 30,
 ) -> Redis:
-    """Create a Redis async client from URL. Connects lazily, on first command."""
+    """Create a Redis async client from URL. Connects lazily, on first command.
+
+    `decode_responses` must stay true: the auth layer compares Lua verdicts
+    against string literals, and the rotation one fails open if they arrive as
+    bytes - a verdict matching none of GRACE, REUSED or INVALID is read as
+    success, which admits a reused refresh token.
+    """
+    if not decode_responses:
+        raise InfrastructureException(
+            "Redis clients must decode responses: the auth layer compares "
+            "Lua verdicts and stored tokens as strings."
+        )
+
     return Redis.from_url(
         connection_url,
         decode_responses=decode_responses,

--- a/src/user/auth/routers.py
+++ b/src/user/auth/routers.py
@@ -187,6 +187,17 @@ async def get_access_by_refresh(
 @router.post(
     "/logout",
     response_model=SuccessResponse,
+    # No CSRF gate here, deliberately. verify_csrf resolves a refresh token first
+    # and answers 401 when the request carries none - and none ever reaches this
+    # route: the refresh cookie is path-scoped to the refresh endpoint, so a
+    # browser client arrives with its access token in the Authorization header,
+    # the one transport the double submit skips by design. The gate would verify
+    # nothing here and would reject the case logout exists for: a client that no
+    # longer holds an access token asking for the httponly cookies it cannot
+    # clear itself. What remains is a cross-site forced logout, which expires two
+    # cookies and nothing else - ending a session server-side needs a signed
+    # access token an attacker cannot forge.
+    #
     # Logout works with expired credentials, so it is an unauthenticated write
     # to Redis; the limiter bounds a flood without hindering a real client.
     dependencies=[Depends(RateLimiter(times=20, minutes=1))],

--- a/src/user/auth/services/email_notifier.py
+++ b/src/user/auth/services/email_notifier.py
@@ -49,13 +49,19 @@ class EmailNotifier:
         self.log_label = log_label
         self.throttle_ttl_sec = throttle_ttl_sec
 
-    async def _throttle_or_touch(self, key: str | None) -> None:
+    async def _claim_throttle_slot(self, key: str | None) -> None:
+        """Take the throttle slot, or refuse the send.
+
+        SET NX in one round trip: reading the key and then writing it lets two
+        concurrent resends both find it absent and both send.
+        """
         if not key or not self.redis_client:
             return
-        existing = await self.redis_client.get(key)
-        if existing:
+        claimed = await self.redis_client.set(
+            key, "1", ex=self.throttle_ttl_sec, nx=True
+        )
+        if not claimed:
             raise InstanceProcessingException(self.throttle_message)
-        await self.redis_client.setex(key, self.throttle_ttl_sec, "1")
 
     async def release_throttle(self, throttle_key: str) -> None:
         """Best-effort throttle release for flows that failed after setting it.
@@ -75,7 +81,7 @@ class EmailNotifier:
         user: User,
         throttle_key: str | None = None,
     ) -> None:
-        await self._throttle_or_touch(throttle_key)
+        await self._claim_throttle_slot(throttle_key)
         try:
             await self.dispatcher.enqueue_transactional(
                 uow,

--- a/src/user/auth/tasks.py
+++ b/src/user/auth/tasks.py
@@ -69,13 +69,18 @@ async def _deliver_tokenized_email(
             template_body=template_body.model_copy(update={"link": link}),
         )
     except Exception:
-        if throttle_key:
-            with suppress(Exception):
-                await redis_client.delete(throttle_key)
+        # Retire the challenge before releasing the throttle, never after: the
+        # throttle is what keeps a resend or a retry from issuing a new
+        # challenge in between, and invalidate() deletes whatever is live by
+        # then - which would be that new one, leaving the user holding a link
+        # that no longer decodes.
         with suppress(Exception):
             await ActiveChallengeRegistry(USER_AUTH_REALM).invalidate(
                 purpose, email, redis_client
             )
+        if throttle_key:
+            with suppress(Exception):
+                await redis_client.delete(throttle_key)
         logger.exception(
             "Failed to process %s email task for %s", purpose, mask_email(email)
         )

--- a/src/user/auth/usecases/reset_password_confirm.py
+++ b/src/user/auth/usecases/reset_password_confirm.py
@@ -6,7 +6,6 @@ import jwt
 from redis.asyncio import Redis
 
 from loggers import get_logger
-from src.core.auth.challenges import ActiveChallengeRegistry
 from src.core.auth.one_time_tokens import decode_one_time_token
 from src.core.auth.token_helpers import invalidate_all_sessions
 from src.core.cache.interface import Cache
@@ -32,10 +31,11 @@ class ResetPasswordConfirmUseCase:
     raising, so a wrong token cannot be told apart from a wrong email.
 
     Side effects:
-    - Deletes the active reset-token key and every session key of the user
-      before the commit rather than after: with Redis unavailable the change
-      then fails as a whole, instead of leaving a new password alongside
-      sessions that still hold the old one.
+    - Deletes every session key of the user before the commit rather than
+      after: with Redis unavailable the change then fails as a whole, instead
+      of leaving a new password alongside sessions that still hold the old one.
+      The reset token itself is already spent by then - decoding consumes it,
+      so two concurrent submissions of one link cannot both set a password.
     - Clears the per-email login-failure counter. The reset proves mailbox
       ownership, so a throttled address must not stay locked out of login.
     - Bumps the user:{id} cache namespace version twice, pre- and post-commit.
@@ -50,7 +50,6 @@ class ResetPasswordConfirmUseCase:
         self.uow = uow
         self.redis_client = redis_client
         self.cache = cache
-        self.challenges = ActiveChallengeRegistry(USER_AUTH_REALM)
 
     async def execute(
         self,
@@ -80,9 +79,6 @@ class ResetPasswordConfirmUseCase:
                     return SuccessResponse(success=False)
 
                 await uow.flush()
-                await self.challenges.invalidate(
-                    RESET_PASSWORD_PURPOSE, normalized_email, self.redis_client
-                )
                 await invalidate_all_sessions(
                     str(user.id), self.redis_client, keys=USER_AUTH_REALM.keys
                 )

--- a/src/user/auth/usecases/verify_email.py
+++ b/src/user/auth/usecases/verify_email.py
@@ -6,7 +6,6 @@ import jwt
 from redis.asyncio import Redis
 
 from loggers import get_logger
-from src.core.auth.challenges import ActiveChallengeRegistry
 from src.core.auth.one_time_tokens import decode_one_time_token
 from src.core.cache.interface import Cache
 from src.core.cache.runtime import get_cache
@@ -29,13 +28,14 @@ class VerifyEmailUseCase:
 
     An invalid, expired or superseded token, and an email naming no user,
     answer success=False instead of raising - the endpoint must not confirm who
-    has an account. A second click on an already used link lands there too: the
-    challenge is invalidated after the commit, so the link no longer decodes.
-    The already-verified branch covers the other case - a token still live for
-    an account that got verified some other way - and answers success for it.
+    has an account. A second click on an already used link lands there too:
+    decoding consumes the challenge, so the link no longer decodes. The
+    already-verified branch covers the other case - a token still live for an
+    account that got verified some other way - and answers success for it.
 
-    Consuming the token after the commit rather than before leaves the link
-    usable when the transaction fails.
+    The token is spent before the transaction runs, which is what stops two
+    concurrent clicks from both proceeding; a failed commit therefore burns the
+    link and the user asks for a new one.
     """
 
     def __init__(
@@ -47,7 +47,6 @@ class VerifyEmailUseCase:
         self.uow = uow
         self.redis_client = redis_client
         self.cache = cache
-        self.challenges = ActiveChallengeRegistry(USER_AUTH_REALM)
 
     async def execute(self, token: str) -> SuccessResponse:
         async with self.uow as uow:
@@ -68,9 +67,6 @@ class VerifyEmailUseCase:
                     )
                     return SuccessResponse(success=False)
                 if not verification_pending(user):
-                    await self.challenges.invalidate(
-                        VERIFICATION_PURPOSE, normalized_email, self.redis_client
-                    )
                     logger.debug(
                         "[VerifyEmail] User with email '%s' already verified.",
                         mask_email(normalized_email),
@@ -87,9 +83,6 @@ class VerifyEmailUseCase:
                     partial(self.cache.invalidate, user_cache_keys.namespace(user.id))
                 )
                 await uow.commit()
-                await self.challenges.invalidate(
-                    VERIFICATION_PURPOSE, normalized_email, self.redis_client
-                )
 
                 logger.info(
                     "[VerifyEmail] User with email '%s' verified successfully.",

--- a/tests/fakes/redis.py
+++ b/tests/fakes/redis.py
@@ -274,7 +274,7 @@ class InMemoryRedis:
 
         normalized = script.strip()
         if normalized == ROTATE_REFRESH_TOKEN_SCRIPT.strip():
-            return await self._eval_rotate_refresh_token(numkeys, *keys_and_args)
+            return self._eval_rotate_refresh_token(numkeys, *keys_and_args)
         if normalized == CONSUME_CHALLENGE_SCRIPT.strip():
             return self._eval_consume_challenge(numkeys, *keys_and_args)
 
@@ -339,13 +339,15 @@ class InMemoryRedis:
             versions.append(version)
         return versions
 
+    # Both script bodies below are synchronous on purpose, and new ones must be
+    # too: an await between the read that decides and the write that acts would
+    # let two callers interleave where real Redis - which runs a script as one
+    # unit - cannot, and a race test would then pass against an implementation
+    # that does not hold. They reach the store directly for the same reason.
     def _eval_consume_challenge(self, numkeys: int, *keys_and_args: Any) -> str:
         if numkeys != 1:
             raise ValueError("CONSUME_CHALLENGE_SCRIPT expects 1 key.")
 
-        # Synchronous on purpose: an await between the read and the delete would
-        # let two callers interleave where real Redis cannot, and a race test
-        # would then pass against an implementation that does not hold.
         challenge_key = _normalize_key(keys_and_args[0])
         presented_value = _normalize_value(keys_and_args[1])
 
@@ -357,7 +359,7 @@ class InMemoryRedis:
         self._expires.pop(challenge_key, None)
         return "OK"
 
-    async def _eval_rotate_refresh_token(
+    def _eval_rotate_refresh_token(
         self,
         numkeys: int,
         *keys_and_args: Any,
@@ -373,7 +375,8 @@ class InMemoryRedis:
 
         now = int(self.wall_clock())
 
-        used_at = await self.get(used_key)
+        self._purge_expired(used_key)
+        used_at = self._store.get(used_key)
         if used_at is not None:
             try:
                 used_at_number: int | None = int(used_at)
@@ -387,12 +390,14 @@ class InMemoryRedis:
                 return "GRACE"
             return "REUSED"
 
-        stored_jti = await self.get(refresh_key)
-        if stored_jti != expected_jti:
+        self._purge_expired(refresh_key)
+        if self._store.get(refresh_key) != expected_jti:
             return "INVALID"
 
-        await self.setex(used_key, used_ttl_seconds, str(now))
-        await self.delete(refresh_key)
+        self._store[used_key] = str(now)
+        self._expires[used_key] = _now() + used_ttl_seconds
+        self._store.pop(refresh_key, None)
+        self._expires.pop(refresh_key, None)
         return "OK"
 
     async def time(self) -> tuple[int, int]:

--- a/tests/fakes/redis.py
+++ b/tests/fakes/redis.py
@@ -8,7 +8,10 @@ from typing import Any
 
 import redis.exceptions as redis_exc
 
-from src.core.auth.redis_scripts import ROTATE_REFRESH_TOKEN_SCRIPT
+from src.core.auth.redis_scripts import (
+    CONSUME_CHALLENGE_SCRIPT,
+    ROTATE_REFRESH_TOKEN_SCRIPT,
+)
 from src.core.cache.redis_scripts import (
     CACHE_DELETE_SCRIPT,
     CACHE_GET_SCRIPT,
@@ -267,6 +270,8 @@ class InMemoryRedis:
         normalized = script.strip()
         if normalized == ROTATE_REFRESH_TOKEN_SCRIPT.strip():
             return await self._eval_rotate_refresh_token(numkeys, *keys_and_args)
+        if normalized == CONSUME_CHALLENGE_SCRIPT.strip():
+            return self._eval_consume_challenge(numkeys, *keys_and_args)
 
         # The cache scripts take a variable number of key arguments - one version
         # counter for the namespace plus one per tag - so the split follows numkeys
@@ -328,6 +333,24 @@ class InMemoryRedis:
             await self.expire(counter, int(args[0]))
             versions.append(version)
         return versions
+
+    def _eval_consume_challenge(self, numkeys: int, *keys_and_args: Any) -> str:
+        # Synchronous on purpose: an await between the read and the delete would
+        # let two callers interleave where real Redis cannot, and a race test
+        # would then pass against an implementation that does not hold.
+        if numkeys != 1:
+            raise ValueError("CONSUME_CHALLENGE_SCRIPT expects 1 key.")
+
+        challenge_key = _normalize_key(keys_and_args[0])
+        presented_value = _normalize_value(keys_and_args[1])
+
+        self._purge_expired(challenge_key)
+        if self._store.get(challenge_key) != presented_value:
+            return "INVALID"
+
+        self._store.pop(challenge_key, None)
+        self._expires.pop(challenge_key, None)
+        return "OK"
 
     async def _eval_rotate_refresh_token(
         self,

--- a/tests/fakes/redis.py
+++ b/tests/fakes/redis.py
@@ -89,8 +89,13 @@ class InMemoryRedis:
         *,
         ex: int | None = None,
         px: int | None = None,
+        nx: bool = False,
     ) -> bool:
         key_norm = _normalize_key(key)
+        if nx:
+            self._purge_expired(key_norm)
+            if key_norm in self._store:
+                return False
         self._store[key_norm] = _normalize_value(value)
         if ex is not None:
             self._expires[key_norm] = _now() + int(ex)
@@ -335,12 +340,12 @@ class InMemoryRedis:
         return versions
 
     def _eval_consume_challenge(self, numkeys: int, *keys_and_args: Any) -> str:
-        # Synchronous on purpose: an await between the read and the delete would
-        # let two callers interleave where real Redis cannot, and a race test
-        # would then pass against an implementation that does not hold.
         if numkeys != 1:
             raise ValueError("CONSUME_CHALLENGE_SCRIPT expects 1 key.")
 
+        # Synchronous on purpose: an await between the read and the delete would
+        # let two callers interleave where real Redis cannot, and a race test
+        # would then pass against an implementation that does not hold.
         challenge_key = _normalize_key(keys_and_args[0])
         presented_value = _normalize_value(keys_and_args[1])
 

--- a/tests/unit/src/core/auth/test_challenges.py
+++ b/tests/unit/src/core/auth/test_challenges.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from src.core.auth.challenges import ActiveChallengeRegistry
@@ -16,12 +18,46 @@ SECOND_REALM = AuthRealm(
 )
 
 
-async def test_the_stored_value_validates(fake_redis: object) -> None:
+async def test_the_stored_value_is_consumed(fake_redis: object) -> None:
     registry = ActiveChallengeRegistry(FIRST_REALM)
 
     await registry.store("verification", "person@example.com", "jti-1", 60, fake_redis)
 
-    await registry.validate("verification", "person@example.com", "jti-1", fake_redis)
+    await registry.consume("verification", "person@example.com", "jti-1", fake_redis)
+
+
+async def test_a_consumed_challenge_cannot_be_consumed_again(
+    fake_redis: object,
+) -> None:
+    """Single use is the whole point: a spent link must stop working."""
+    registry = ActiveChallengeRegistry(FIRST_REALM)
+    await registry.store("verification", "person@example.com", "jti-1", 60, fake_redis)
+    await registry.consume("verification", "person@example.com", "jti-1", fake_redis)
+
+    with pytest.raises(UnauthorizedException):
+        await registry.consume(
+            "verification", "person@example.com", "jti-1", fake_redis
+        )
+
+
+async def test_only_one_of_two_concurrent_consumers_wins(fake_redis: object) -> None:
+    """Two requests holding one code must not both be admitted.
+
+    A check-then-delete registry passes the check in both before either deletes,
+    which is how one OTP or one reset link logs in twice.
+    """
+    registry = ActiveChallengeRegistry(FIRST_REALM)
+    await registry.store("verification", "person@example.com", "jti-1", 60, fake_redis)
+
+    outcomes = await asyncio.gather(
+        registry.consume("verification", "person@example.com", "jti-1", fake_redis),
+        registry.consume("verification", "person@example.com", "jti-1", fake_redis),
+        return_exceptions=True,
+    )
+
+    failures = [outcome for outcome in outcomes if isinstance(outcome, Exception)]
+    assert len(failures) == 1
+    assert isinstance(failures[0], UnauthorizedException)
 
 
 async def test_a_superseded_value_is_rejected(fake_redis: object) -> None:
@@ -31,9 +67,28 @@ async def test_a_superseded_value_is_rejected(fake_redis: object) -> None:
     await registry.store("verification", "person@example.com", "jti-2", 60, fake_redis)
 
     with pytest.raises(UnauthorizedException):
-        await registry.validate(
+        await registry.consume(
             "verification", "person@example.com", "jti-1", fake_redis
         )
+
+
+async def test_a_rejected_value_leaves_the_live_challenge_alone(
+    fake_redis: object,
+) -> None:
+    """Consumption is a compare-and-delete, never a plain GETDEL.
+
+    Deleting on a mismatch would let an old link retire the one its owner is
+    waiting on - a hand-me-down denial of service on every issued challenge.
+    """
+    registry = ActiveChallengeRegistry(FIRST_REALM)
+    await registry.store("verification", "person@example.com", "jti-2", 60, fake_redis)
+
+    with pytest.raises(UnauthorizedException):
+        await registry.consume(
+            "verification", "person@example.com", "jti-1", fake_redis
+        )
+
+    await registry.consume("verification", "person@example.com", "jti-2", fake_redis)
 
 
 async def test_a_missing_value_is_rejected(fake_redis: object) -> None:
@@ -41,7 +96,7 @@ async def test_a_missing_value_is_rejected(fake_redis: object) -> None:
     await registry.store("verification", "person@example.com", "jti-1", 60, fake_redis)
 
     with pytest.raises(UnauthorizedException):
-        await registry.validate("verification", "person@example.com", None, fake_redis)
+        await registry.consume("verification", "person@example.com", None, fake_redis)
 
 
 async def test_invalidation_clears_the_challenge(fake_redis: object) -> None:
@@ -51,7 +106,7 @@ async def test_invalidation_clears_the_challenge(fake_redis: object) -> None:
     await registry.invalidate("verification", "person@example.com", fake_redis)
 
     with pytest.raises(UnauthorizedException):
-        await registry.validate(
+        await registry.consume(
             "verification", "person@example.com", "jti-1", fake_redis
         )
 
@@ -66,7 +121,7 @@ async def test_one_realm_cannot_clear_another_realm_challenge(
 
     await second.invalidate("verification", "person@example.com", fake_redis)
 
-    await first.validate("verification", "person@example.com", "jti-1", fake_redis)
+    await first.consume("verification", "person@example.com", "jti-1", fake_redis)
 
 
 async def test_the_identifier_never_appears_in_the_key(fake_redis: object) -> None:

--- a/tests/unit/src/core/auth/test_challenges.py
+++ b/tests/unit/src/core/auth/test_challenges.py
@@ -1,4 +1,5 @@
 import asyncio
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -16,6 +17,7 @@ SECOND_REALM = AuthRealm(
     session_secret=lambda: "second-realm-secret-not-real-32-char",
     refresh_cookie_path="/v1/second/auth/login/refresh",
 )
+CHALLENGE_KEY = FIRST_REALM.keys.one_time("verification", "person@example.com")
 
 
 async def test_the_stored_value_is_consumed(fake_redis: object) -> None:
@@ -24,6 +26,31 @@ async def test_the_stored_value_is_consumed(fake_redis: object) -> None:
     await registry.store("verification", "person@example.com", "jti-1", 60, fake_redis)
 
     await registry.consume("verification", "person@example.com", "jti-1", fake_redis)
+
+    assert await fake_redis.exists(CHALLENGE_KEY) == 0
+
+
+async def test_consume_touches_redis_exactly_once(fake_redis: object) -> None:
+    """Two round trips are two chances to interleave, whatever the second one is.
+
+    The fake cannot suspend inside a call, so a rewrite of consume() into an
+    awaited GET plus an awaited DEL would still produce one winner there and the
+    race test above would stay green. This one trips on the shape instead.
+    """
+    registry = ActiveChallengeRegistry(FIRST_REALM)
+    await registry.store("verification", "person@example.com", "jti-1", 60, fake_redis)
+    eval_spy = AsyncMock(wraps=fake_redis.eval)
+    get_spy = AsyncMock(wraps=fake_redis.get)
+    delete_spy = AsyncMock(wraps=fake_redis.delete)
+    fake_redis.eval = eval_spy
+    fake_redis.get = get_spy
+    fake_redis.delete = delete_spy
+
+    await registry.consume("verification", "person@example.com", "jti-1", fake_redis)
+
+    assert eval_spy.await_count == 1
+    get_spy.assert_not_awaited()
+    delete_spy.assert_not_awaited()
 
 
 async def test_a_consumed_challenge_cannot_be_consumed_again(

--- a/tests/unit/src/core/redis/test_redis_core.py
+++ b/tests/unit/src/core/redis/test_redis_core.py
@@ -1,0 +1,21 @@
+import pytest
+
+from src.core.errors.exceptions import InfrastructureException
+from src.core.redis.core import create_redis_client
+
+
+def test_a_client_decodes_responses_by_default() -> None:
+    client = create_redis_client("redis://localhost:6379/0")
+
+    assert client.connection_pool.connection_kwargs["decode_responses"] is True
+
+
+def test_a_client_that_would_return_bytes_is_refused() -> None:
+    """The rotation script's verdict fails open when it arrives as bytes.
+
+    A bytes verdict matches none of GRACE, REUSED or INVALID, so
+    execute_token_rotation reads it as success and admits a reused refresh
+    token. The client that would produce it must not be constructible.
+    """
+    with pytest.raises(InfrastructureException):
+        create_redis_client("redis://localhost:6379/0", decode_responses=False)

--- a/tests/unit/src/user/auth/services/test_email_notifier.py
+++ b/tests/unit/src/user/auth/services/test_email_notifier.py
@@ -99,6 +99,32 @@ async def test_email_notifier_rejects_throttled_requests(
 
 
 @pytest.mark.asyncio
+async def test_email_notifier_claims_the_throttle_slot_without_reading_it(
+    fake_redis: InMemoryRedis,
+    fake_uow: FakeUnitOfWork,
+) -> None:
+    """Reading the key and then writing it lets two resends both find it absent.
+
+    The claim has to be one SET NX, so a separate read of the throttle key is
+    the shape of the bug rather than a detail of it.
+    """
+    notifier = build_notifier(
+        AsyncMock(), fake_redis, send_verification_email_task, "throttled", "log"
+    )
+    user = build_user(email="user@example.com")
+    throttle_key = build_throttle_key("resend_verification", user.email)
+    get_spy = AsyncMock(wraps=fake_redis.get)
+    fake_redis.get = get_spy  # type: ignore[method-assign]
+
+    await notifier.send(uow=fake_uow, user=user, throttle_key=throttle_key)
+
+    get_spy.assert_not_awaited()
+    assert await fake_redis.exists(throttle_key) == 1
+    with pytest.raises(InstanceProcessingException):
+        await notifier.send(uow=fake_uow, user=user, throttle_key=throttle_key)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("task", "throttle_message", "log_label", "throttle_namespace"), NOTIFIER_CONFIGS
 )

--- a/tests/unit/src/user/auth/test_auth_routers.py
+++ b/tests/unit/src/user/auth/test_auth_routers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock
 
 from fastapi.routing import APIRoute
@@ -11,7 +12,11 @@ from src.core.database.session import get_unit_of_work
 from src.core.limiter.depends import RateLimiter
 from src.core.redis.dependencies import get_redis_client
 from src.core.schemas import SuccessResponse, TokenModel
-from src.user.auth.dependencies import get_access_by_refresh_token, get_logout_identity
+from src.user.auth.dependencies import (
+    get_access_by_refresh_token,
+    get_logout_identity,
+    verify_csrf,
+)
 from src.user.auth.realm import USER_AUTH_REALM
 from src.user.auth.routers import router
 from src.user.auth.usecases.login import get_login_user_use_case
@@ -69,6 +74,21 @@ def _get_route_rate_limiters(route: APIRoute) -> list[RateLimiter]:
         for dependency in route.dependant.dependencies
         if isinstance(dependency.call, RateLimiter)
     ]
+
+
+def _get_route_dependency_calls(route: APIRoute) -> list[Any]:
+    """Every callable the route resolves, route-level and nested alike.
+
+    A gate declared on a sub-dependency counts as declared on the route, so the
+    whole tree is walked rather than only its first level.
+    """
+    calls: list[Any] = []
+    pending = list(route.dependant.dependencies)
+    while pending:
+        dependency = pending.pop()
+        calls.append(dependency.call)
+        pending.extend(dependency.dependencies)
+    return calls
 
 
 @pytest.fixture(autouse=True)
@@ -379,6 +399,28 @@ def test_verify_email_route_has_rate_limit() -> None:
     assert len(rate_limiters) == 1
     assert rate_limiters[0].times == 30
     assert rate_limiters[0].milliseconds == 15 * 60_000
+
+
+def test_logout_route_has_no_csrf_gate() -> None:
+    """verify_csrf resolves a refresh token first, and none reaches this route.
+
+    The refresh cookie is path-scoped to the refresh endpoint, so a browser
+    arrives at logout with its access token in the Authorization header - the
+    one transport the double submit skips. The gate would check nothing here
+    and would 401 the credential-less logout, which exists so a client can shed
+    the httponly cookies it cannot clear itself.
+    """
+    logout_dependencies = _get_route_dependency_calls(
+        _get_auth_route(path="/logout", method="POST")
+    )
+    # The refresh route is the control: a walker that found nothing would pass
+    # the logout assertion for the wrong reason.
+    refresh_dependencies = _get_route_dependency_calls(
+        _get_auth_route(path="/login/refresh", method="POST")
+    )
+
+    assert verify_csrf not in logout_dependencies
+    assert verify_csrf in refresh_dependencies
 
 
 def test_logout_route_has_rate_limit() -> None:

--- a/tests/unit/src/user/auth/usecases/test_auth_usecases_stage1.py
+++ b/tests/unit/src/user/auth/usecases/test_auth_usecases_stage1.py
@@ -684,11 +684,16 @@ async def test_verify_email_usecase_cannot_reuse_successful_token(
 
 
 @pytest.mark.asyncio
-async def test_verify_email_usecase_commit_failure_keeps_token_active(
+async def test_verify_email_usecase_commit_failure_still_consumes_the_token(
     fake_session: FakeAsyncSession,
     fake_redis: InMemoryRedis,
     cache: InMemoryCache,
 ) -> None:
+    """The link is spent before the transaction runs, and a failure keeps it spent.
+
+    Handing it back on failure is what would let two concurrent clicks through:
+    the price of the single-use guarantee is a new link after a failed commit.
+    """
     user = build_user(is_verified=False)
     users_repo = FakeUsersRepository(user=user, updated_user=user)
     uow = build_uow(fake_session, users_repo)
@@ -703,7 +708,7 @@ async def test_verify_email_usecase_commit_failure_keeps_token_active(
         await fake_redis.exists(
             USER_AUTH_REALM.keys.one_time(VERIFICATION_PURPOSE, user.email)
         )
-        == 1
+        == 0
     )
     uow.flush.assert_not_awaited()
     uow.rollback.assert_awaited_once()


### PR DESCRIPTION
Single-use challenges were checked and deleted in two round-trips, so two requests presenting the same value could both pass. `ActiveChallengeRegistry.validate` is replaced by `consume`, a Lua compare-and-delete: exactly one caller gets through, and returning means the challenge is already spent. It is not `GETDEL` — that would delete on a mismatch too, letting anyone holding a superseded value retire the challenge its owner is still waiting on. `invalidate` stays for a caller abandoning a challenge rather than acting on it, and the email notifier now retires the challenge before releasing the resend throttle, and claims that throttle in one `SET NX` instead of a read followed by a write.

`create_redis_client` now refuses `decode_responses=False`: the rotation script's verdicts are compared as strings, and bytes would match none of them and read as success.

Testing: `pytest` — 974 passed.
