### PR TITLE
fix(migrations): generate modern union typing in revision template

### DIFF
--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -5,7 +5,8 @@ Revises: ${down_revision | comma,n}
 Create Date: ${create_date}
 
 """
-from typing import Sequence, Union
+
+from collections.abc import Sequence
 
 from alembic import op
 import sqlalchemy as sa
@@ -13,9 +14,9 @@ ${imports if imports else ""}
 
 # revision identifiers, used by Alembic.
 revision: str = ${repr(up_revision)}
-down_revision: Union[str, None] = ${repr(down_revision)}
-branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
-depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+down_revision: str | None = ${repr(down_revision)}
+branch_labels: str | Sequence[str] | None = ${repr(branch_labels)}
+depends_on: str | Sequence[str] | None = ${repr(depends_on)}
 
 
 def upgrade() -> None:


### PR DESCRIPTION
A revision generated from `script.py.mako` imported `typing.Sequence` and `typing.Union`, so `pyupgrade` and `black` rewrote every fresh migration on its first `pre-commit` run. The template now emits `from collections.abc import Sequence` and `str | None` / `str | Sequence[str] | None`, matching the committed revisions, and a newly generated file passes the hooks untouched.

Testing: `pytest` — 966 passed.
