### PR TITLE
refactor(auth): express throttle keys through one realm-scoped builder method

### DIFF
--- a/src/core/auth/redis_keys.py
+++ b/src/core/auth/redis_keys.py
@@ -26,9 +26,18 @@ class AuthRedisKeyBuilder:
         sessions: stale members are pruned on the next token issuance."""
         return f"{self._prefix}:sessions:{subject_id}"
 
+    def throttle(self, scope: str, identifier: str) -> str:
+        """A realm-scoped, window-based counter key for one identifier.
+
+        `scope` names what is being limited ("login-fail", "otp-cooldown");
+        the identifier is hashed, so an email or a phone number never reaches
+        SCAN, MONITOR or an RDB dump.
+        """
+        return f"{self._prefix}:{build_throttle_key(scope, identifier)}"
+
     def login_failures(self, identifier: str) -> str:
         """Window-scoped counter of failed logins for one login identifier."""
-        return f"{self._prefix}:{build_throttle_key('login-fail', identifier)}"
+        return self.throttle("login-fail", identifier)
 
     def one_time(self, purpose: str, identifier: str) -> str:
         """The single active challenge for one purpose and one identifier."""

--- a/src/user/auth/usecases/resend_verification.py
+++ b/src/user/auth/usecases/resend_verification.py
@@ -7,7 +7,8 @@ from src.core.database.session import get_unit_of_work
 from src.core.database.uow import ApplicationUnitOfWork
 from src.core.errors.exceptions import InstanceProcessingException
 from src.core.schemas import SuccessResponse
-from src.core.utils.security import build_throttle_key, mask_email
+from src.core.utils.security import mask_email
+from src.user.auth.realm import USER_AUTH_REALM
 from src.user.auth.schemas import ResendVerificationModel
 from src.user.auth.services.email_notifier import (
     EmailNotifier,
@@ -53,7 +54,9 @@ class SendVerificationUseCase:
                 )
                 return SuccessResponse(success=True)
 
-            throttle_key = build_throttle_key("resend_verification", user.email)
+            throttle_key = USER_AUTH_REALM.keys.throttle(
+                "resend_verification", user.email
+            )
             try:
                 await self.notifier.send(
                     uow=uow,

--- a/src/user/auth/usecases/reset_password_request.py
+++ b/src/user/auth/usecases/reset_password_request.py
@@ -7,7 +7,8 @@ from src.core.database.session import get_unit_of_work
 from src.core.database.uow import ApplicationUnitOfWork
 from src.core.errors.exceptions import InstanceProcessingException
 from src.core.schemas import SuccessResponse
-from src.core.utils.security import build_throttle_key, mask_email
+from src.core.utils.security import mask_email
+from src.user.auth.realm import USER_AUTH_REALM
 from src.user.auth.schemas import SendResetPasswordRequestModel
 from src.user.auth.services.email_notifier import (
     EmailNotifier,
@@ -45,7 +46,7 @@ class ResetPasswordRequestUseCase:
                 )
                 return SuccessResponse(success=True)
 
-            throttle_key = build_throttle_key("password-reset", user.email)
+            throttle_key = USER_AUTH_REALM.keys.throttle("password-reset", user.email)
             try:
                 await self.notifier.send(
                     uow=uow,

--- a/tests/unit/src/core/auth/test_redis_keys.py
+++ b/tests/unit/src/core/auth/test_redis_keys.py
@@ -30,3 +30,26 @@ def test_two_realms_never_share_a_key() -> None:
 
     assert first.sessions("42") != second.sessions("42")
     assert first.refresh("42", "s1") != second.refresh("42", "s1")
+
+
+def test_throttle_key_is_realm_scoped_and_hashes_the_identifier() -> None:
+    """Two realms must never share a throttle counter, and a phone number must
+    not reach SCAN, MONITOR or an RDB dump in the clear."""
+    client_keys = AuthRedisKeyBuilder("client")
+    staff_keys = AuthRedisKeyBuilder("staff")
+
+    client_key = client_keys.throttle("otp-cooldown", "+998901234567")
+    staff_key = staff_keys.throttle("otp-cooldown", "+998901234567")
+
+    assert client_key.startswith("client:otp-cooldown:")
+    assert staff_key.startswith("staff:otp-cooldown:")
+    assert client_key != staff_key
+    assert "+998901234567" not in client_key
+
+
+def test_login_failures_is_a_throttle_scope() -> None:
+    """login_failures must keep producing the exact key it produced before the
+    generic method existed, or every live lockout counter is orphaned."""
+    keys = AuthRedisKeyBuilder("client")
+
+    assert keys.login_failures("someone") == keys.throttle("login-fail", "someone")

--- a/tests/unit/src/user/auth/usecases/test_auth_usecases_stage1.py
+++ b/tests/unit/src/user/auth/usecases/test_auth_usecases_stage1.py
@@ -9,7 +9,6 @@ import pytest
 from src.core.cache.memory_cache import InMemoryCache
 from src.core.errors.exceptions import InstanceProcessingException
 from src.core.schemas import SuccessResponse
-from src.core.utils.security import build_throttle_key
 from src.main.config import config
 from src.user.auth.realm import (
     RESET_PASSWORD_PURPOSE,
@@ -186,7 +185,9 @@ async def test_resend_verification_success(
     result = await use_case.execute(data=ResendVerificationModel(email=user.email))
 
     assert result == SuccessResponse(success=True)
-    expected_throttle_key = build_throttle_key("resend_verification", user.email)
+    expected_throttle_key = USER_AUTH_REALM.keys.throttle(
+        "resend_verification", user.email
+    )
     notifier.send.assert_awaited_once_with(
         uow=uow, user=user, throttle_key=expected_throttle_key
     )
@@ -230,7 +231,9 @@ async def test_resend_verification_releases_throttle_when_commit_fails(
             data=ResendVerificationModel(email=user.email),
         )
 
-    expected_throttle_key = build_throttle_key("resend_verification", user.email)
+    expected_throttle_key = USER_AUTH_REALM.keys.throttle(
+        "resend_verification", user.email
+    )
     notifier.release_throttle.assert_awaited_once_with(expected_throttle_key)
 
 
@@ -270,7 +273,7 @@ async def test_reset_password_request_success(
     result = await use_case.execute(data=data)
 
     assert result == SuccessResponse(success=True)
-    expected_throttle_key = build_throttle_key("password-reset", user.email)
+    expected_throttle_key = USER_AUTH_REALM.keys.throttle("password-reset", user.email)
     notifier.send.assert_awaited_once_with(
         uow=uow, user=user, throttle_key=expected_throttle_key
     )
@@ -294,7 +297,7 @@ async def test_reset_password_request_releases_throttle_when_commit_fails(
             data=SendResetPasswordRequestModel(email=user.email),
         )
 
-    expected_throttle_key = build_throttle_key("password-reset", user.email)
+    expected_throttle_key = USER_AUTH_REALM.keys.throttle("password-reset", user.email)
     notifier.release_throttle.assert_awaited_once_with(expected_throttle_key)
 
 


### PR DESCRIPTION
`AuthRedisKeyBuilder` exposed only `login_failures`, so a realm needing any other window-based counter — an OTP resend cooldown, a daily send allowance, a verification attempt budget — had to assemble the key at the call site, against the rule that auth Redis keys come only from the builder. It gains a generic `throttle(scope, identifier)`, and every producer now goes through it: `login_failures` delegates to it, and the password-reset and resend-verification flows stop calling `build_throttle_key` directly, which had been putting their counters outside the realm namespace entirely.

The identifier stays hashed, so a phone number or an email never reaches SCAN, MONITOR or an RDB dump. The key `login_failures` produces is unchanged; the two email flows' keys gain the realm prefix, so a counter live at deploy resets — a throttle window, not state worth carrying over.

Testing: `pytest` — 968 passed.
