### PR TITLE
ci: let Coveralls comment on the pull request again

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -167,6 +167,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
+    # The only job that writes anything back to the pull request. The Coveralls
+    # action does not post the comment itself - it hands this token to
+    # coveralls.io as COVERALLS_REPO_TOKEN and the service posts as itself, so a
+    # read-only token uploads the report and silently leaves no comment. Granted
+    # here rather than at the workflow level so the jobs running third-party
+    # scanners keep a read-only token.
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -207,6 +217,8 @@ jobs:
           export PATH="$PWD/.venv/bin:$PATH"
           make test-cov
 
+      # A pull request from a fork gets a read-only token whatever this asks
+      # for, so the report lands on coveralls.io and the comment does not.
       - name: Upload coverage to Coveralls
         continue-on-error: true
         uses: coverallsapp/github-action@v2.3.8

--- a/.github/workflows/prod_ci.yml
+++ b/.github/workflows/prod_ci.yml
@@ -10,9 +10,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# The ceiling for _ci.yml: a called workflow can never hold more than its
+# caller. Coveralls comments on the pull request with the token CI hands it,
+# and only the unit-tests job actually takes the write.
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/prod_ci.yml
+++ b/.github/workflows/prod_ci.yml
@@ -10,12 +10,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# The ceiling for _ci.yml: a called workflow can never hold more than its
-# caller. Coveralls comments on the pull request with the token CI hands it,
-# and only the unit-tests job actually takes the write.
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -32,7 +29,11 @@ jobs:
     # request, so it gets only the one secret _ci.yml actually declares.
     secrets:
       GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+    # The ceiling for _ci.yml: a called workflow can never hold more than the
+    # job that calls it, and this block - not the workflow-level one above -
+    # is what that job holds. Coveralls comments on the pull request with the
+    # token CI hands it, and only _ci.yml's unit-tests job takes the write.
     permissions:
       contents: read
       packages: write
-      pull-requests: read
+      pull-requests: write

--- a/.github/workflows/stage_ci.yml
+++ b/.github/workflows/stage_ci.yml
@@ -10,12 +10,9 @@ on:
     branches: [stage]
   workflow_dispatch:
 
-# The ceiling for _ci.yml: a called workflow can never hold more than its
-# caller. Coveralls comments on the pull request with the token CI hands it,
-# and only the unit-tests job actually takes the write.
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -31,7 +28,11 @@ jobs:
     # request, so it gets only the one secret _ci.yml actually declares.
     secrets:
       GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+    # The ceiling for _ci.yml: a called workflow can never hold more than the
+    # job that calls it, and this block - not the workflow-level one above -
+    # is what that job holds. Coveralls comments on the pull request with the
+    # token CI hands it, and only _ci.yml's unit-tests job takes the write.
     permissions:
       contents: read
       packages: write
-      pull-requests: read
+      pull-requests: write

--- a/.github/workflows/stage_ci.yml
+++ b/.github/workflows/stage_ci.yml
@@ -10,9 +10,12 @@ on:
     branches: [stage]
   workflow_dispatch:
 
+# The ceiling for _ci.yml: a called workflow can never hold more than its
+# caller. Coveralls comments on the pull request with the token CI hands it,
+# and only the unit-tests job actually takes the write.
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
The Coveralls action does not post its comment itself: it forwards the workflow's `GITHUB_TOKEN` to coveralls.io as `COVERALLS_REPO_TOKEN`, and the service posts as itself with that token. Since the workflow started declaring `permissions` the token has been read-only, so every report since April has uploaded and none has commented — invisibly, because the step carries `continue-on-error`.

`pull-requests: write` now lands on the unit-tests job in `_ci.yml`, and on the `ci` job of `prod_ci.yml` and `stage_ci.yml`, which is the ceiling a called workflow inherits — the workflow-level block above it does not apply to a job that declares its own. Every job running a third-party scanner keeps a read-only token.

A pull request from a fork still gets a read-only token whatever this asks for, so the report lands and the comment does not.

Testing: this PR itself — the comment either appears on it or the change did not work.
