### PR TITLE
fix(auth): make the rotation verdict fail closed

### DIFF
--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -10,11 +10,11 @@ from collections.abc import Sequence
 
 from alembic import op
 import sqlalchemy as sa
-${imports if imports else ""}
+${imports + "\n" if imports else ""}\
 
 # revision identifiers, used by Alembic.
-revision: str = ${repr(up_revision)}
-down_revision: str | None = ${repr(down_revision)}
+revision: str = "${up_revision}"
+down_revision: str | None = ${'"%s"' % down_revision if down_revision else "None"}
 branch_labels: str | Sequence[str] | None = ${repr(branch_labels)}
 depends_on: str | Sequence[str] | None = ${repr(depends_on)}
 

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -13,10 +13,24 @@ import sqlalchemy as sa
 ${imports + "\n" if imports else ""}\
 
 # revision identifiers, used by Alembic.
+<%!
+def as_literal(value):
+    """repr() with double quotes, so black leaves a fresh revision alone.
+
+    A merge revision's down_revision is a sequence of parents, not a string;
+    rendering it with %s would name one revision that does not exist and the
+    merge would never find its branches.
+    """
+    if value is None:
+        return "None"
+    if isinstance(value, str):
+        return '"%s"' % value
+    return "(%s)" % "".join('"%s", ' % item for item in value).rstrip(", ")
+%>\
 revision: str = "${up_revision}"
-down_revision: str | None = ${'"%s"' % down_revision if down_revision else "None"}
-branch_labels: str | Sequence[str] | None = ${repr(branch_labels)}
-depends_on: str | Sequence[str] | None = ${repr(depends_on)}
+down_revision: str | Sequence[str] | None = ${as_literal(down_revision)}
+branch_labels: str | Sequence[str] | None = ${as_literal(branch_labels)}
+depends_on: str | Sequence[str] | None = ${as_literal(depends_on)}
 
 
 def upgrade() -> None:

--- a/src/core/auth/credentials.py
+++ b/src/core/auth/credentials.py
@@ -95,7 +95,12 @@ async def verify_jti(token: str, redis_client: Redis, realm: AuthRealm) -> JWTPa
         raise UnauthorizedException("Invalid token structure")
 
     if mode == "refresh_token":
-        used_marker = await redis_client.get(realm.keys.used(subject_id, jti))
+        # redis-py types every reply as bytes-or-str because its stubs cannot
+        # see decode_responses; create_redis_client fixes it on, so what
+        # arrives here is a string.
+        used_marker = cast(
+            str | None, await redis_client.get(realm.keys.used(subject_id, jti))
+        )
 
         if used_marker is not None:
             # Inside the grace window this is a benign double-submit, not
@@ -110,13 +115,7 @@ async def verify_jti(token: str, redis_client: Redis, realm: AuthRealm) -> JWTPa
     active_key = realm.keys.session_key(mode, subject_id, session_id)
     stored_jti = await redis_client.get(active_key)
 
-    stored_jti_str = (
-        stored_jti.decode()
-        if isinstance(stored_jti, (bytes, bytearray))
-        else stored_jti
-    )
-
-    if not stored_jti or stored_jti_str != jti:
+    if not stored_jti or stored_jti != jti:
         raise UnauthorizedException(
             "Token invalidated or expired",
         )

--- a/src/core/auth/token_helpers.py
+++ b/src/core/auth/token_helpers.py
@@ -8,11 +8,14 @@ from typing import cast
 
 from redis.asyncio import Redis
 
+from loggers import get_logger
 from src.core.auth.jwt_payload_schema import JWTPayload
 from src.core.auth.redis_keys import AuthRedisKeyBuilder
 from src.core.auth.redis_scripts import ROTATE_REFRESH_TOKEN_SCRIPT
 from src.core.errors.exceptions import UnauthorizedException
 from src.main.config import config
+
+logger = get_logger(__name__)
 
 
 async def invalidate_all_sessions(
@@ -86,9 +89,7 @@ async def validate_token_structure(
     return subject_id, session_id, jti
 
 
-async def is_within_reuse_grace(
-    used_marker: str | bytes | None, redis_client: Redis
-) -> bool:
+async def is_within_reuse_grace(used_marker: str | None, redis_client: Redis) -> bool:
     """A used marker younger than the grace window marks a benign double-submit.
 
     Takes the already-fetched marker value so the caller's existence check and
@@ -122,10 +123,10 @@ async def execute_token_rotation(
     Run the rotation script and translate its verdict.
 
     Answers 'OK' or raises; there is no other return. GRACE is a double-submit
-    inside the reuse window and leaves the session family intact, while REUSED
-    and INVALID wipe every session of the subject first. All three raise 401
+    inside the reuse window and leaves the session family intact; every other
+    verdict wipes each of the subject's sessions first. All of them raise 401
     under one error code, but the message a detected reuse carries differs from
-    the other two and reaches the client - only the code is uniform.
+    the rest and reaches the client - only the code is uniform.
     """
 
     refresh_ttl_seconds = config.jwt.REFRESH_TOKEN_EXPIRE_MINUTES * 60
@@ -150,16 +151,28 @@ async def execute_token_rotation(
         ),
     )
 
+    if result == "OK":
+        return result
+
     if result == "GRACE":
         # A double-submit inside the grace window: reject the request but do
         # not treat it as theft - the family wipe would log out a subject whose
         # client merely retried a refresh over a flaky connection.
         raise UnauthorizedException("Token invalidated or expired")
-    if result == "REUSED":
-        await invalidate_all_sessions(subject_id, redis_client, keys=keys)
-        raise UnauthorizedException("Token reuse detected. All sessions invalidated.")
-    if result == "INVALID":
-        await invalidate_all_sessions(subject_id, redis_client, keys=keys)
-        raise UnauthorizedException("Token invalidated or expired")
 
-    return result
+    # Everything that is not one of the script's four verdicts lands here, and
+    # lands on the side of wiping. A verdict this code does not recognise means
+    # the script, the client or whatever sits between them is not what this
+    # function thinks it is, and rotation is the one place where guessing
+    # "probably fine" hands out a session against a token nothing verified.
+    if result != "REUSED" and result != "INVALID":
+        logger.error(
+            "[RotateRefreshToken] Unrecognised rotation verdict %r; "
+            "treating it as a reuse and wiping every session of the subject",
+            result,
+        )
+
+    await invalidate_all_sessions(subject_id, redis_client, keys=keys)
+    if result == "REUSED":
+        raise UnauthorizedException("Token reuse detected. All sessions invalidated.")
+    raise UnauthorizedException("Token invalidated or expired")

--- a/src/core/redis/core.py
+++ b/src/core/redis/core.py
@@ -1,32 +1,22 @@
 from redis.asyncio import Redis
 
-from src.core.errors.exceptions import InfrastructureException
-
 
 def create_redis_client(
     connection_url: str,
     *,
-    decode_responses: bool = True,
     socket_timeout: float = 5.0,
     socket_connect_timeout: float = 5.0,
     health_check_interval: int = 30,
 ) -> Redis:
     """Create a Redis async client from URL. Connects lazily, on first command.
 
-    `decode_responses` must stay true: the auth layer compares Lua verdicts
-    against string literals, and the rotation one fails open if they arrive as
-    bytes - a verdict matching none of GRACE, REUSED or INVALID is read as
-    success, which admits a reused refresh token.
+    Decoding is not a parameter: the auth layer compares Lua verdicts and
+    stored jti values against string literals, and every one of those
+    comparisons is wrong against bytes. No caller may ask for the other one.
     """
-    if not decode_responses:
-        raise InfrastructureException(
-            "Redis clients must decode responses: the auth layer compares "
-            "Lua verdicts and stored tokens as strings."
-        )
-
     return Redis.from_url(
         connection_url,
-        decode_responses=decode_responses,
+        decode_responses=True,
         socket_timeout=socket_timeout,
         socket_connect_timeout=socket_connect_timeout,
         health_check_interval=health_check_interval,

--- a/src/user/auth/routers.py
+++ b/src/user/auth/routers.py
@@ -187,16 +187,10 @@ async def get_access_by_refresh(
 @router.post(
     "/logout",
     response_model=SuccessResponse,
-    # No CSRF gate here, deliberately. verify_csrf resolves a refresh token first
-    # and answers 401 when the request carries none - and none ever reaches this
-    # route: the refresh cookie is path-scoped to the refresh endpoint, so a
-    # browser client arrives with its access token in the Authorization header,
-    # the one transport the double submit skips by design. The gate would verify
-    # nothing here and would reject the case logout exists for: a client that no
-    # longer holds an access token asking for the httponly cookies it cannot
-    # clear itself. What remains is a cross-site forced logout, which expires two
-    # cookies and nothing else - ending a session server-side needs a signed
-    # access token an attacker cannot forge.
+    # No verify_csrf here: it resolves a refresh token first and answers 401
+    # without one, and the refresh cookie is path-scoped to the refresh route,
+    # so none ever reaches logout. A forged cross-site logout expires two
+    # cookies; ending a session server-side needs a signed access token.
     #
     # Logout works with expired credentials, so it is an unauthenticated write
     # to Redis; the limiter bounds a flood without hindering a real client.

--- a/src/user/auth/tasks.py
+++ b/src/user/auth/tasks.py
@@ -69,11 +69,11 @@ async def _deliver_tokenized_email(
             template_body=template_body.model_copy(update={"link": link}),
         )
     except Exception:
-        # Retire the challenge before releasing the throttle, never after: the
-        # throttle is what keeps a resend or a retry from issuing a new
-        # challenge in between, and invalidate() deletes whatever is live by
-        # then - which would be that new one, leaving the user holding a link
-        # that no longer decodes.
+        # Retire the challenge before releasing the throttle, never after:
+        # while the throttle is held no resend can have stored a newer
+        # challenge, and invalidate() deletes whatever is live by then - after
+        # the release that could be the new one, leaving the user holding a
+        # link that no longer decodes.
         with suppress(Exception):
             await ActiveChallengeRegistry(USER_AUTH_REALM).invalidate(
                 purpose, email, redis_client

--- a/tests/fakes/redis.py
+++ b/tests/fakes/redis.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 import fnmatch
 import hashlib
@@ -34,6 +35,17 @@ def _normalize_value(value: Any) -> str:
 
 def _now() -> float:
     return time.monotonic()
+
+
+async def _round_trip() -> None:
+    """Yield the way a real command does, so concurrent callers interleave.
+
+    Without this every method here runs start to finish before the event loop
+    looks at anyone else, and a race test passes against an implementation that
+    reads and writes in two round trips - which is the bug those tests exist to
+    catch. Script bodies must not call this: Redis runs a script as one unit.
+    """
+    await asyncio.sleep(0)
 
 
 class InMemoryRedis:
@@ -78,6 +90,7 @@ class InMemoryRedis:
             self._expires.pop(key, None)
 
     async def get(self, key: str | bytes) -> str | None:
+        await _round_trip()
         key_norm = _normalize_key(key)
         self._purge_expired(key_norm)
         return self._store.get(key_norm)
@@ -91,6 +104,7 @@ class InMemoryRedis:
         px: int | None = None,
         nx: bool = False,
     ) -> bool:
+        await _round_trip()
         key_norm = _normalize_key(key)
         if nx:
             self._purge_expired(key_norm)
@@ -106,9 +120,11 @@ class InMemoryRedis:
         return True
 
     async def setex(self, key: str | bytes, time_seconds: int, value: Any) -> bool:
+        await _round_trip()
         return await self.set(key, value, ex=time_seconds)
 
     async def delete(self, *keys: str | bytes) -> int:
+        await _round_trip()
         deleted = 0
         for key in keys:
             key_norm = _normalize_key(key)
@@ -121,11 +137,13 @@ class InMemoryRedis:
         return deleted
 
     async def exists(self, key: str | bytes) -> int:
+        await _round_trip()
         key_norm = _normalize_key(key)
         self._purge_expired(key_norm)
         return int(key_norm in self._store or key_norm in self._zsets)
 
     async def expire(self, key: str | bytes, seconds: int, *, nx: bool = False) -> bool:
+        await _round_trip()
         key_norm = _normalize_key(key)
         self._purge_expired(key_norm)
         if key_norm not in self._store and key_norm not in self._zsets:
@@ -136,6 +154,7 @@ class InMemoryRedis:
         return True
 
     async def incr(self, key: str | bytes) -> int:
+        await _round_trip()
         key_norm = _normalize_key(key)
         self._purge_expired(key_norm)
         # Writes the store directly: set() would drop the TTL, but Redis INCR
@@ -212,6 +231,7 @@ class InMemoryRedis:
         return self._zsets.get(key_norm, {}).get(_normalize_value(member))
 
     async def ttl(self, key: str | bytes) -> int:
+        await _round_trip()
         key_norm = _normalize_key(key)
         self._purge_expired(key_norm)
         if key_norm not in self._store and key_norm not in self._zsets:

--- a/tests/fakes/redis.py
+++ b/tests/fakes/redis.py
@@ -89,6 +89,29 @@ class InMemoryRedis:
             self._zsets.pop(key, None)
             self._expires.pop(key, None)
 
+    def _read(self, key: str) -> str | None:
+        """The store as a script sees it: no yield, no round trip."""
+        self._purge_expired(key)
+        return self._store.get(key)
+
+    def _write(self, key: str, value: str, *, ttl_seconds: int | None = None) -> None:
+        self._store[key] = value
+        if ttl_seconds is not None:
+            self._expires[key] = _now() + int(ttl_seconds)
+
+    def _drop(self, key: str) -> int:
+        self._purge_expired(key)
+        if key not in self._store and key not in self._zsets:
+            return 0
+        self._store.pop(key, None)
+        self._zsets.pop(key, None)
+        self._expires.pop(key, None)
+        return 1
+
+    def _expire(self, key: str, seconds: int) -> None:
+        if key in self._store or key in self._zsets:
+            self._expires[key] = _now() + int(seconds)
+
     async def get(self, key: str | bytes) -> str | None:
         await _round_trip()
         key_norm = _normalize_key(key)
@@ -304,66 +327,64 @@ class InMemoryRedis:
         counters = [_normalize_key(key) for key in keys_and_args[:numkeys]]
         args = keys_and_args[numkeys:]
         if normalized == CACHE_GET_SCRIPT.strip():
-            return await self._eval_cache_get(counters, *args)
+            return self._eval_cache_get(counters, *args)
         if normalized == CACHE_SET_SCRIPT.strip():
-            return await self._eval_cache_set(counters, *args)
+            return self._eval_cache_set(counters, *args)
         if normalized == CACHE_DELETE_SCRIPT.strip():
-            return await self._eval_cache_delete(counters, *args)
+            return self._eval_cache_delete(counters, *args)
         if normalized == CACHE_INVALIDATE_SCRIPT.strip():
-            return await self._eval_cache_invalidate(counters, *args)
+            return self._eval_cache_invalidate(counters, *args)
         raise NotImplementedError("Script not supported in fake Redis.")
 
-    async def _cache_value_key(
-        self, counters: list[str], prefix_ns: str, suffix: str
-    ) -> str:
-        versions = [await self.get(counter) or "0" for counter in counters]
+    # Every script body below is synchronous, and a new one must be too: an
+    # await between the read that decides and the write that acts would let two
+    # callers interleave where real Redis - which runs a script as one unit -
+    # cannot. A race test would then pass against an implementation that does
+    # not hold, and a cache test would see a version counter Redis can never
+    # produce. They reach the store through _read/_write/_drop/_expire for the
+    # same reason: the public commands yield.
+    def _cache_value_key(self, counters: list[str], prefix_ns: str, suffix: str) -> str:
+        versions = [self._read(counter) or "0" for counter in counters]
         return f"{prefix_ns}:v{'.'.join(versions)}:{suffix}"
 
-    async def _eval_cache_get(self, counters: list[str], *args: Any) -> str | None:
+    def _eval_cache_get(self, counters: list[str], *args: Any) -> str | None:
         self.cache_eval_calls += 1
-        key = await self._cache_value_key(
+        key = self._cache_value_key(
             counters,
             _normalize_value(args[0]),
             _normalize_value(args[1]),
         )
-        return await self.get(key)
+        return self._read(key)
 
-    async def _eval_cache_set(self, counters: list[str], *args: Any) -> int:
+    def _eval_cache_set(self, counters: list[str], *args: Any) -> int:
         self.cache_eval_calls += 1
-        key = await self._cache_value_key(
+        key = self._cache_value_key(
             counters,
             _normalize_value(args[0]),
             _normalize_value(args[1]),
         )
-        await self.setex(key, int(args[3]), _normalize_value(args[2]))
+        self._write(key, _normalize_value(args[2]), ttl_seconds=int(args[3]))
         for counter in counters:
-            await self.expire(counter, int(args[4]))
+            self._expire(counter, int(args[4]))
         return 1
 
-    async def _eval_cache_delete(self, counters: list[str], *args: Any) -> int:
-        key = await self._cache_value_key(
+    def _eval_cache_delete(self, counters: list[str], *args: Any) -> int:
+        key = self._cache_value_key(
             counters,
             _normalize_value(args[0]),
             _normalize_value(args[1]),
         )
-        return await self.delete(key)
+        return self._drop(key)
 
-    async def _eval_cache_invalidate(
-        self, counters: list[str], *args: Any
-    ) -> list[int]:
+    def _eval_cache_invalidate(self, counters: list[str], *args: Any) -> list[int]:
         versions = []
         for counter in counters:
-            version = int(await self.get(counter) or "0") + 1
-            await self.set(counter, str(version))
-            await self.expire(counter, int(args[0]))
+            version = int(self._read(counter) or "0") + 1
+            self._write(counter, str(version))
+            self._expire(counter, int(args[0]))
             versions.append(version)
         return versions
 
-    # Both script bodies below are synchronous on purpose, and new ones must be
-    # too: an await between the read that decides and the write that acts would
-    # let two callers interleave where real Redis - which runs a script as one
-    # unit - cannot, and a race test would then pass against an implementation
-    # that does not hold. They reach the store directly for the same reason.
     def _eval_consume_challenge(self, numkeys: int, *keys_and_args: Any) -> str:
         if numkeys != 1:
             raise ValueError("CONSUME_CHALLENGE_SCRIPT expects 1 key.")

--- a/tests/unit/src/core/auth/test_challenges.py
+++ b/tests/unit/src/core/auth/test_challenges.py
@@ -1,5 +1,4 @@
 import asyncio
-from unittest.mock import AsyncMock
 
 import pytest
 
@@ -28,29 +27,6 @@ async def test_the_stored_value_is_consumed(fake_redis: object) -> None:
     await registry.consume("verification", "person@example.com", "jti-1", fake_redis)
 
     assert await fake_redis.exists(CHALLENGE_KEY) == 0
-
-
-async def test_consume_touches_redis_exactly_once(fake_redis: object) -> None:
-    """Two round trips are two chances to interleave, whatever the second one is.
-
-    The fake cannot suspend inside a call, so a rewrite of consume() into an
-    awaited GET plus an awaited DEL would still produce one winner there and the
-    race test above would stay green. This one trips on the shape instead.
-    """
-    registry = ActiveChallengeRegistry(FIRST_REALM)
-    await registry.store("verification", "person@example.com", "jti-1", 60, fake_redis)
-    eval_spy = AsyncMock(wraps=fake_redis.eval)
-    get_spy = AsyncMock(wraps=fake_redis.get)
-    delete_spy = AsyncMock(wraps=fake_redis.delete)
-    fake_redis.eval = eval_spy
-    fake_redis.get = get_spy
-    fake_redis.delete = delete_spy
-
-    await registry.consume("verification", "person@example.com", "jti-1", fake_redis)
-
-    assert eval_spy.await_count == 1
-    get_spy.assert_not_awaited()
-    delete_spy.assert_not_awaited()
 
 
 async def test_a_consumed_challenge_cannot_be_consumed_again(

--- a/tests/unit/src/core/redis/test_redis_core.py
+++ b/tests/unit/src/core/redis/test_redis_core.py
@@ -1,21 +1,9 @@
-import pytest
-
-from src.core.errors.exceptions import InfrastructureException
 from src.core.redis.core import create_redis_client
 
 
-def test_a_client_decodes_responses_by_default() -> None:
+def test_a_client_decodes_responses() -> None:
+    """Every auth comparison - Lua verdicts, stored jti values - is a string
+    comparison, and each one is wrong against bytes."""
     client = create_redis_client("redis://localhost:6379/0")
 
     assert client.connection_pool.connection_kwargs["decode_responses"] is True
-
-
-def test_a_client_that_would_return_bytes_is_refused() -> None:
-    """The rotation script's verdict fails open when it arrives as bytes.
-
-    A bytes verdict matches none of GRACE, REUSED or INVALID, so
-    execute_token_rotation reads it as success and admits a reused refresh
-    token. The client that would produce it must not be constructible.
-    """
-    with pytest.raises(InfrastructureException):
-        create_redis_client("redis://localhost:6379/0", decode_responses=False)

--- a/tests/unit/src/core/redis/test_redis_lifecycle.py
+++ b/tests/unit/src/core/redis/test_redis_lifecycle.py
@@ -17,7 +17,7 @@ async def test_on_redis_startup_and_shutdown(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(
         lifecycle,
         "create_redis_client",
-        lambda connection_url, decode_responses=True: client,
+        lambda connection_url: client,
     )
 
     app = SimpleNamespace(state=SimpleNamespace())

--- a/tests/unit/src/user/auth/test_token_helpers_security.py
+++ b/tests/unit/src/user/auth/test_token_helpers_security.py
@@ -386,6 +386,25 @@ async def test_execute_token_rotation_invalid(
 
 
 @pytest.mark.asyncio
+async def test_execute_token_rotation_treats_an_unknown_verdict_as_reuse(
+    fake_redis: InMemoryRedis, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only 'OK' may return. A verdict this code does not recognise means the
+    script, the client or something between them is not what the caller thinks
+    it is, and rotation is where reading it as success hands out a session."""
+    monkeypatch.setattr(fake_redis, "eval", AsyncMock(return_value="SOMETHING-ELSE"))
+    invalidate_mock = AsyncMock()
+    monkeypatch.setattr(token_helpers, "invalidate_all_sessions", invalidate_mock)
+
+    with pytest.raises(UnauthorizedException):
+        await token_helpers.execute_token_rotation(
+            "u1", "s1", "j1", fake_redis, keys=AUTH_KEYS
+        )
+
+    invalidate_mock.assert_awaited_once_with("u1", fake_redis, keys=AUTH_KEYS)
+
+
+@pytest.mark.asyncio
 async def test_execute_token_rotation_ok(fake_redis: InMemoryRedis) -> None:
     """
     Given: active refresh key exists and no used-token marker is present.


### PR DESCRIPTION
Seven findings from a review of the atomic-consume change, in dependency order.

`execute_token_rotation` matched GRACE, REUSED and INVALID and returned anything else, where a return means success — the fail-open the `decode_responses` guard treated a symptom of. Only `OK` returns now; an unrecognised verdict wipes the session family and is logged at error.

That makes the guard belt-and-braces, so `decode_responses` stops being a parameter with one legal value, and the bytes-decoding branch in `verify_jti` goes with it. One `cast` at the boundary says why redis-py's stubs disagree.

`InMemoryRedis` had no suspension point anywhere, so every race test passed by construction — the headline one passed against an awaited GET plus an awaited DEL. Plain commands now yield; every script body reaches the store directly instead, so an emulated script still runs as one unit.

Also: two comments trimmed, and `script.py.mako` renders a revision — merge revisions included — that survives its first `pre-commit` run untouched.

Testing: `pytest` — 975 passed.
