### PR TITLE
fix(infra): publish Postgres and Redis on loopback in the base compose file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,9 @@ POSTGRES_USER=admin
 POSTGRES_PASSWORD=example-postgres-password-not-real
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
+# Host side of the 127.0.0.1 bind in infra/docker-compose.yml, default 5432.
+# Change it only when that port is taken on the host; POSTGRES_PORT stays 5432.
+# POSTGRES_HOST_PORT=5432
 POSTGRES_DB=postgres
 # API pool; tasks pool serves the taskiq worker - DB_TASKS_POOL_SIZE +
 # DB_TASKS_MAX_OVERFLOW must cover --max-async-tasks (infra/docker-compose.yml).
@@ -61,6 +64,8 @@ DB_TASKS_MAX_OVERFLOW=15
 REDIS_HOST=redis
 REDIS_PASSWORD=example-redis-password-not-real
 REDIS_PORT=6379
+# Host side of the 127.0.0.1 bind in infra/docker-compose.yml, default 6379.
+# REDIS_HOST_PORT=6379
 REDIS_DATABASE=0
 REDIS_TASKS_DATABASE=1
 

--- a/README.md
+++ b/README.md
@@ -213,14 +213,14 @@ fresh empty volumes.
 - Run a focused file with `TESTING=true pytest tests/unit/src/<module>/test_<name>.py`.
 
 ## Ports
-Only Nginx is published to the host; the rest stay internal to `app-network`.
-Backing ports are re-exposed on `127.0.0.1` in dev (`make run-dev`) only — see
-`docs/readme/security.md` → *Host Port Exposure (Docker & UFW)*.
+Only Nginx is published on a public address. Postgres and Redis are published on
+`127.0.0.1` everywhere, so a server's database is one SSH tunnel away; the app
+port only in dev — see `docs/readme/security.md` → *Host Port Exposure (Docker & UFW)*.
 
 - Nginx: 80 / 443 → app:8001 — **public** (`0.0.0.0`); dev publishes 8000 instead
 - App direct: 8001 — internal (dev: `127.0.0.1`)
-- Postgres: 5432 — internal (dev: `127.0.0.1`)
-- Redis: 6379 — internal (dev: `127.0.0.1`)
+- Postgres: `POSTGRES_PORT` (5432) — `127.0.0.1`
+- Redis: `REDIS_PORT` (6379) — `127.0.0.1`
 
 On a server, close everything else with `infra/firewall/` (UFW plus a
 `DOCKER-USER` chain, since Docker-published ports bypass UFW):

--- a/README.md
+++ b/README.md
@@ -219,8 +219,8 @@ port only in dev — see `docs/readme/security.md` → *Host Port Exposure (Dock
 
 - Nginx: 80 / 443 → app:8001 — **public** (`0.0.0.0`); dev publishes 8000 instead
 - App direct: 8001 — internal (dev: `127.0.0.1`)
-- Postgres: `POSTGRES_PORT` (5432) — `127.0.0.1`
-- Redis: `REDIS_PORT` (6379) — `127.0.0.1`
+- Postgres: 5432 — `127.0.0.1:${POSTGRES_HOST_PORT:-5432}`
+- Redis: 6379 — `127.0.0.1:${REDIS_HOST_PORT:-6379}`
 
 On a server, close everything else with `infra/firewall/` (UFW plus a
 `DOCKER-USER` chain, since Docker-published ports bypass UFW):

--- a/docs/readme/infra.md
+++ b/docs/readme/infra.md
@@ -2,22 +2,23 @@
 
 ## Services and Ports
 
-Only **Nginx** is published to the host. All other services are internal-only —
-they talk to each other over the `app-network` bridge by service name and are
-never bound to a host interface in production.
+Only **Nginx** is published on a public address. The services talk to each other
+over the `app-network` bridge by service name; Postgres and Redis are also
+published on the host's loopback, so a server's data stores are one SSH tunnel
+away.
 
 | Service | Port | Host exposure |
 |---|---|---|
 | Nginx | 80 / 443 | **Public** (`0.0.0.0`) — proxies to `app:8001`; dev publishes `8000` instead |
 | App | 8001 | Internal only (dev: `127.0.0.1:8001` for direct access) |
-| Postgres | 5432 | Internal only (dev: `127.0.0.1:5432`) |
-| Redis | 6379 | Internal only (dev: `127.0.0.1:6379`) |
+| Postgres | 5432 | `127.0.0.1:${POSTGRES_HOST_PORT:-5432}`, every environment |
+| Redis | 6379 | `127.0.0.1:${REDIS_HOST_PORT:-6379}`, every environment |
 
-Backing-service host ports live **only** in `docker-compose.override.yml` (dev)
-and are bound to `127.0.0.1`. `make run` / `make up` (base file) publish nothing
-but Nginx. This avoids exposing data stores to the internet via the Docker
-iptables/UFW bypass — see `docs/readme/security.md` → *Host Port Exposure
-(Docker & UFW)*.
+`POSTGRES_HOST_PORT` / `REDIS_HOST_PORT` move only the host side of those binds,
+for a box where the default port is taken; `POSTGRES_PORT` / `REDIS_PORT` stay
+what the app dials inside the network. Loopback binds cannot be reached from the
+network, so the Docker iptables/UFW bypass does not apply — see
+`docs/readme/security.md` → *Host Port Exposure (Docker & UFW)*.
 
 Configs live in `infra/` (compose, nginx, dockerfiles, redis/postgres, requirements).
 
@@ -122,7 +123,7 @@ make clean            # remove stack + volumes/images/orphans
 - `APP_IMAGE` is the only knob: unset, every service falls back to the locally built `template-app-image:latest`, so `make run` and `make run-dev` behave exactly as before.
 - The box needs `docker login ghcr.io` credentials for a private package (`GHCR_USER` / `GHCR_PULL_TOKEN`, secrets of that box's GitHub Environment). Postgres stays a box-local build — CD ships application code, never the database image.
 - `infra/docker-compose.yml` is production-oriented and does not mount host source code into `app`, `worker`, or `scheduler`.
-- It also publishes **only** the Nginx port to the host; Postgres/Redis/app stay internal to `app-network`. If you genuinely need a backing port on the host in production, bind it to `127.0.0.1` (or restrict it via a `DOCKER-USER` firewall rule) — never the short `host:container` syntax, which binds `0.0.0.0` and bypasses UFW. See `docs/readme/security.md`.
+- It publishes Nginx publicly and Postgres/Redis on `127.0.0.1` only; the app stays internal to `app-network`. Any further host port follows the same rule: bind it to `127.0.0.1` (or restrict it via a `DOCKER-USER` firewall rule) — never the short `host:container` syntax, which binds `0.0.0.0` and bypasses UFW. See `docs/readme/security.md`.
 - Source bind mounts remain only in `infra/docker-compose.override.yml` for local development.
 - `infra/nginx/app.conf` sets baseline security headers at the reverse-proxy layer, while the FastAPI app keeps the same headers as a fallback for direct app access and tests. The proxy body itself lives in `infra/nginx/proxy.inc`, shared with the TLS server so the two cannot drift apart. Dev serves the same `app.conf`, only on a different published port.
 - TLS terminates at Nginx: copy `infra/nginx/tls.conf.example` over the `app.conf` mount, put the certificate under `infra/nginx/certs/` (git-ignored) and set the real hostname. It redirects plain http to https and leaves the ACME challenge path reachable.

--- a/docs/readme/security.md
+++ b/docs/readme/security.md
@@ -220,7 +220,7 @@ when UFW reports the port as blocked.
   `app-network` bridge by service name (`postgres:5432`, `redis:6379`,
   `app:8001`).
 - Postgres and Redis are also published on the host's `127.0.0.1`
-  (`POSTGRES_PORT`, `REDIS_PORT`), so an operator reaches them through an SSH
+  (`POSTGRES_HOST_PORT`, `REDIS_HOST_PORT`), so an operator reaches them through an SSH
   tunnel and host-side integration tests reach them locally. Loopback binds are
   not reachable from the network, so the iptables bypass does not apply. The dev
   overlay (`docker-compose.override.yml`, local-only) adds the app port on

--- a/docs/readme/security.md
+++ b/docs/readme/security.md
@@ -215,15 +215,16 @@ effect** on a container-published port: it is reachable from the internet even
 when UFW reports the port as blocked.
 
 **What the template does:**
-- The base (production) compose file publishes **only Nginx (`80` and `443`)** to
-  the host. Postgres, Redis, and the app stay off the host — they communicate
-  over the internal `app-network` bridge by service name (`postgres:5432`,
-  `redis:6379`, `app:8001`), so they are unreachable from outside the host
-  regardless of firewall state.
-- The dev overlay (`docker-compose.override.yml`, local-only) re-exposes those
-  backing services bound to `127.0.0.1` for debugging and host-side integration
-  tests. Loopback binds are not reachable from the network, so the iptables
-  bypass does not apply.
+- The base (production) compose file publishes **only Nginx (`80` and `443`)** on
+  a public address. The services talk to each other over the internal
+  `app-network` bridge by service name (`postgres:5432`, `redis:6379`,
+  `app:8001`).
+- Postgres and Redis are also published on the host's `127.0.0.1`
+  (`POSTGRES_PORT`, `REDIS_PORT`), so an operator reaches them through an SSH
+  tunnel and host-side integration tests reach them locally. Loopback binds are
+  not reachable from the network, so the iptables bypass does not apply. The dev
+  overlay (`docker-compose.override.yml`, local-only) adds the app port on
+  `127.0.0.1` the same way.
 
 **The remaining public ports (Nginx, `80`/`443`):** these are the intended front
 door and are published on `0.0.0.0` by design. Because of the bypass above, UFW
@@ -247,7 +248,7 @@ policy from UFW alone.
 
 **Why it matters:** publishing Postgres/Redis on `0.0.0.0` exposes
 unauthenticated-by-default data stores to the internet, silently bypassing the
-host firewall. Keeping backing services off the host and constraining the one
+host firewall. Keeping backing services on loopback and constraining the one
 public port via `DOCKER-USER`/`ufw-docker` closes that gap.
 
 ## Nginx Hardening

--- a/infra/docker-compose.override.yml
+++ b/infra/docker-compose.override.yml
@@ -42,15 +42,3 @@ services:
     # already sits.
     ports: !override
       - "8000:80"
-
-  # Backing services are not published in the base (prod) compose file. Re-expose
-  # them here on 127.0.0.1 only, for local debugging and host-side integration
-  # tests (.env.test uses localhost). Loopback binds are not reachable from the
-  # network, so the Docker/UFW iptables bypass does not apply.
-  postgres:
-    ports:
-      - "127.0.0.1:${POSTGRES_PORT}:5432"
-
-  redis:
-    ports:
-      - "127.0.0.1:${REDIS_PORT}:6379"

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -24,10 +24,11 @@ services:
     restart: always
     shm_size: 256m
     # Loopback only: an operator reaches it through an SSH tunnel to 127.0.0.1 on
-    # the host, the network never does (docs/readme/security.md). Host-side
-    # integration tests use the same port locally.
+    # the host, the network never does (docs/readme/security.md). The host side is
+    # its own variable: POSTGRES_PORT is what the app dials inside the network, and
+    # the container always listens on 5432.
     ports:
-      - "127.0.0.1:${POSTGRES_PORT}:5432"
+      - "127.0.0.1:${POSTGRES_HOST_PORT:-5432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s
@@ -167,9 +168,9 @@ services:
     container_name: template-redis
     image: 'redis:8.10'
     restart: unless-stopped
-    # Loopback only, for the same reason as postgres above.
+    # Loopback only, host port decoupled from REDIS_PORT, as for postgres above.
     ports:
-      - "127.0.0.1:${REDIS_PORT}:6379"
+      - "127.0.0.1:${REDIS_HOST_PORT:-6379}:6379"
     env_file: ../.env
     healthcheck:
       # Plain `redis-cli ping` exits 0 even on NOAUTH under requirepass, so a

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -23,6 +23,11 @@ services:
     image: template-postgres:18
     restart: always
     shm_size: 256m
+    # Loopback only: an operator reaches it through an SSH tunnel to 127.0.0.1 on
+    # the host, the network never does (docs/readme/security.md). Host-side
+    # integration tests use the same port locally.
+    ports:
+      - "127.0.0.1:${POSTGRES_PORT}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s
@@ -162,6 +167,9 @@ services:
     container_name: template-redis
     image: 'redis:8.10'
     restart: unless-stopped
+    # Loopback only, for the same reason as postgres above.
+    ports:
+      - "127.0.0.1:${REDIS_PORT}:6379"
     env_file: ../.env
     healthcheck:
       # Plain `redis-cli ping` exits 0 even on NOAUTH under requirepass, so a

--- a/infra/firewall/README.md
+++ b/infra/firewall/README.md
@@ -40,7 +40,7 @@ ssh -L 5432:127.0.0.1:5432 <host>    # Postgres
 ssh -L 6379:127.0.0.1:6379 <host>    # Redis
 ```
 
-The compose file publishes both on the host's loopback (`POSTGRES_PORT`,
-`REDIS_PORT`), so a database client tunnelling to `127.0.0.1` on the host - an
-IDE's SSH tunnel included - reaches a deployed stack the same way it reaches a
-local one.
+The compose file publishes both on the host's loopback (`POSTGRES_HOST_PORT`,
+`REDIS_HOST_PORT`, defaults 5432 and 6379), so a database client tunnelling to
+`127.0.0.1` on the host - an IDE's SSH tunnel included - reaches a deployed
+stack the same way it reaches a local one.

--- a/infra/firewall/README.md
+++ b/infra/firewall/README.md
@@ -1,10 +1,10 @@
 # Host firewall
 
 Only `22`, `80` and `443` are reachable from the internet on a deployed host -
-which is exactly what the production compose file publishes (Nginx on `80`/`443`).
-Everything else - Postgres, Redis, the worker and scheduler, the app port,
-anything a neighbouring compose project publishes - is reachable through an SSH
-tunnel only.
+Nginx is the only service the compose file publishes on a public address.
+Everything else - Postgres and Redis (published on `127.0.0.1` only), the worker
+and scheduler, the app port, anything a neighbouring compose project publishes -
+is reachable through an SSH tunnel only.
 
 ## Apply
 
@@ -29,16 +29,18 @@ and is the supported place to filter that traffic, so the two scripts split
 along the same line: `ufw` for host listeners, `DOCKER-USER` for containers.
 `docs/readme/security.md` explains the bypass in more detail.
 
-This is a second line of defence, not the first one: the production compose file
-publishes nothing but Nginx, and the dev overlay binds the backing services to
+This is a second line of defence, not the first one: the compose file publishes
+nothing but Nginx on a public address and binds Postgres and Redis to
 `127.0.0.1`, which the network cannot reach regardless of firewall state.
 
 ## Reaching an internal service
 
 ```bash
 ssh -L 5432:127.0.0.1:5432 <host>    # Postgres
+ssh -L 6379:127.0.0.1:6379 <host>    # Redis
 ```
 
-Those host ports exist only when the dev overlay is in use; the production stack
-keeps the backing services on the compose network, reachable from the host with
-`docker compose exec`.
+The compose file publishes both on the host's loopback (`POSTGRES_PORT`,
+`REDIS_PORT`), so a database client tunnelling to `127.0.0.1` on the host - an
+IDE's SSH tunnel included - reaches a deployed stack the same way it reaches a
+local one.


### PR DESCRIPTION
A deployed stack kept Postgres and Redis on the compose network only, so an SSH tunnel to `127.0.0.1` on the host - what a database IDE opens - was refused, leaving `docker compose exec` as the only way in.

Both are now published on `127.0.0.1` in the base compose file (`POSTGRES_PORT`, `REDIS_PORT`); the dev overlay no longer repeats them. `infra/firewall/README.md`, `docs/readme/security.md` and the README port list describe the tunnel.

Security: loopback binds are unreachable from the network, and the `DOCKER-USER` chain still drops everything but 80/443 on the public interface. Nginx remains the only publicly published service.

Testing: `docker compose config` for the base file and base + dev overlay shows exactly one `127.0.0.1` mapping per service; pre-commit on the changed files.